### PR TITLE
Use SHELFBOT_HAS_LIDAR and initialize LidarSensor; update rclc timer API calls

### DIFF
--- a/components/sensor_control/include/sensor_control.hpp
+++ b/components/sensor_control/include/sensor_control.hpp
@@ -2,11 +2,11 @@
 #pragma once
 #include <idf_c_includes.hpp>
 #include "sensor_common.hpp"
+#include "lidar_sensor.hpp"
 
 // Forward declarations
 class UltrasonicSensorArray;
 class TofSensor;
-class LidarSensor;
 
 class SensorControl {
 public:

--- a/components/sensor_control/sensor_control.cpp
+++ b/components/sensor_control/sensor_control.cpp
@@ -2,6 +2,7 @@
 #include "sensor_control.hpp"
 #include "ultrasonic_sensor.hpp"
 #include "tof_sensor.hpp"
+#include "lidar_sensor.hpp"
 #include "sensor_common.hpp"
 #include "firmware_version.hpp"
 
@@ -98,6 +99,10 @@ esp_err_t SensorControl::initialize_tof() {
     }
 
     ESP_LOGI(TAG, "TOF sensors initialized successfully");
+#if SHELFBOT_HAS_LIDAR
+    lidar_sensor_ = std::make_unique<LidarSensor>(tof_sensor_.get());
+    ESP_LOGI(TAG, "LidarSensor initialized");
+#endif
     return ESP_OK;
 }
 
@@ -231,7 +236,7 @@ void SensorControl::continuous_read_loop() {
             }
 
             latest_data_.timestamp_us = timestamp;
-#if SHELFBOT_ENABLE_LIDAR
+#if SHELFBOT_HAS_LIDAR
             latest_data_.lidar_measurement.distance_mm = latest_data_.tof_measurements[0].distance_mm;
             latest_data_.lidar_measurement.valid = latest_data_.tof_measurements[0].valid;
             latest_data_.lidar_measurement.status = latest_data_.tof_measurements[0].status;

--- a/components/sensor_control/sensor_manager.cpp
+++ b/components/sensor_control/sensor_manager.cpp
@@ -74,7 +74,7 @@ void SensorManager::initialize(const SensorControl::Config& config) {
                     latest_data_.ultrasonic_readings[i].distance_cm = distances[i] / 10.0f;
                 }
                 latest_data_.timestamp_us = esp_timer_get_time();
-#if SHELFBOT_ENABLE_LIDAR
+#if SHELFBOT_HAS_LIDAR
                 latest_data_.lidar_measurement.distance_mm = latest_data_.tof_measurements[0].distance_mm;
                 latest_data_.lidar_measurement.valid = latest_data_.tof_measurements[0].valid;
                 latest_data_.lidar_measurement.status = latest_data_.tof_measurements[0].status;
@@ -93,7 +93,7 @@ void SensorManager::initialize(const SensorControl::Config& config) {
                     latest_data_.tof_measurements[i] = measurements[i];
                 }
                 latest_data_.timestamp_us = esp_timer_get_time();
-#if SHELFBOT_ENABLE_LIDAR
+#if SHELFBOT_HAS_LIDAR
                 latest_data_.lidar_measurement.distance_mm = latest_data_.tof_measurements[0].distance_mm;
                 latest_data_.lidar_measurement.valid = latest_data_.tof_measurements[0].valid;
                 latest_data_.lidar_measurement.status = latest_data_.tof_measurements[0].status;
@@ -127,7 +127,7 @@ void SensorManager::initialize(const SensorControl::Config& config) {
         latest_data_.tof_measurements[i] = SensorCommon::TofMeasurement();
     }
     latest_data_.timestamp_us = 0;
-#if SHELFBOT_ENABLE_LIDAR
+#if SHELFBOT_HAS_LIDAR
     latest_data_.lidar_measurement = SensorCommon::LidarMeasurement();
 #endif
 

--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -180,11 +180,11 @@ void Shelfbot::create_entities() {
     RCCHECK(rclc_subscription_init_default(&led_subscription, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool), "shelfbot_firmware/led"));
 
     // Timers
-    RCCHECK(rclc_timer_init_default2(&heartbeat_timer, &support, RCL_MS_TO_NS(1000), heartbeat_timer_callback_wrapper, true));
-    RCCHECK(rclc_timer_init_default2(&motor_position_timer, &support, RCL_MS_TO_NS(100), motor_position_timer_callback_wrapper, true));
-    RCCHECK(rclc_timer_init_default2(&distance_sensors_timer, &support, RCL_MS_TO_NS(200), distance_sensors_timer_callback_wrapper, true));
-    RCCHECK(rclc_timer_init_default2(&led_state_timer, &support, RCL_MS_TO_NS(2000), led_state_timer_callback_wrapper, true));
-    RCCHECK(rclc_timer_init_default2(&tof_timer, &support, RCL_MS_TO_NS(100), tof_timer_callback_wrapper, true));
+    RCCHECK(rclc_timer_init_default(&heartbeat_timer, &support, RCL_MS_TO_NS(1000), heartbeat_timer_callback_wrapper));
+    RCCHECK(rclc_timer_init_default(&motor_position_timer, &support, RCL_MS_TO_NS(100), motor_position_timer_callback_wrapper));
+    RCCHECK(rclc_timer_init_default(&distance_sensors_timer, &support, RCL_MS_TO_NS(200), distance_sensors_timer_callback_wrapper));
+    RCCHECK(rclc_timer_init_default(&led_state_timer, &support, RCL_MS_TO_NS(2000), led_state_timer_callback_wrapper));
+    RCCHECK(rclc_timer_init_default(&tof_timer, &support, RCL_MS_TO_NS(100), tof_timer_callback_wrapper));
 
     // Executor
     unsigned int num_handles = 5 + 3; // 5 timers + 3 subs


### PR DESCRIPTION
### Motivation
- Unify and switch the lidar compile-time guard to `SHELFBOT_HAS_LIDAR` and wire up a `LidarSensor` instance when TOF sensors are present to support lidar features.
- Update the ROS 2 timer initialization calls to the `rclc` API change that uses `rclc_timer_init_default` instead of `rclc_timer_init_default2`.

### Description
- Added `#include "lidar_sensor.hpp"` to `sensor_control.hpp` and `sensor_control.cpp` and removed the manual forward declaration for `LidarSensor`.
- Instantiate and assign `lidar_sensor_` in `SensorControl::initialize_tof()` under the `#if SHELFBOT_HAS_LIDAR` guard, passing the `TofSensor` pointer to the `LidarSensor` constructor.
- Replaced preprocessor checks from `SHELFBOT_ENABLE_LIDAR` to `SHELFBOT_HAS_LIDAR` in `sensor_control.cpp` and `sensor_manager.cpp` so lidar measurements are populated from TOF data when enabled.
- Replaced calls to `rclc_timer_init_default2(..., true)` with `rclc_timer_init_default(...)` in `shelfbot.cpp` to match the updated `rclc` API signature.

### Testing
- Performed a full firmware build using the project build system which completed successfully (`idf.py build`).
- Ran the project's existing unit/integration tests where available and observed no regressions (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78a4c05548322a9183c991d2b4f05)