### PR TITLE
Add Lidar measurement status helper, consolidate LIDAR macro, and update rclc timer API usage

### DIFF
--- a/components/http_server/http_server.cpp
+++ b/components/http_server/http_server.cpp
@@ -253,6 +253,29 @@ std::string HttpServer::get_sensor_status_text(const SensorCommon::TofMeasuremen
         default: return "unknown";
     }
 }
+std::string HttpServer::get_sensor_status_text(const SensorCommon::LidarMeasurement& measurement) {
+    if (!measurement.valid) {
+        return "invalid";
+    }
+
+    switch (measurement.status) {
+        case 0: return "ok";
+        case 1: return "sigma_fail";
+        case 2: return "signal_fail";
+        case 3: return "min_range_fail";
+        case 4: return "phase_fail";
+        case 5: return "hw_fail";
+        case 6: return "range_valid_min_range_clipped";
+        case 7: return "sync_int_fail";
+        case 8: return "no_update";
+        case 9: return "wrapped_target_fail";
+        case 10: return "processing_fail";
+        case 11: return "x_talk_fail";
+        case 12: return "range_ignore_threshold";
+        default: return "unknown";
+    }
+}
+
 
 cJSON* HttpServer::create_tof_json(const SensorCommon::SensorDataPacket& sensor_data) {
     cJSON* tof_array = cJSON_CreateArray();

--- a/components/http_server/include/http_server.hpp
+++ b/components/http_server/include/http_server.hpp
@@ -45,6 +45,7 @@ private:
 
   // Helper functions
   static std::string get_sensor_status_text(const SensorCommon::TofMeasurement& measurement);
+  static std::string get_sensor_status_text(const SensorCommon::LidarMeasurement& measurement);
   static cJSON* create_sensor_json(const SensorCommon::SensorDataPacket& sensor_data);
   static cJSON* create_ultrasonic_json(const SensorCommon::SensorDataPacket& sensor_data);
   static cJSON* create_tof_json(const SensorCommon::SensorDataPacket& sensor_data);

--- a/components/sensor_control/include/sensor_control.hpp
+++ b/components/sensor_control/include/sensor_control.hpp
@@ -2,11 +2,11 @@
 #pragma once
 #include <idf_c_includes.hpp>
 #include "sensor_common.hpp"
+#include "lidar_sensor.hpp"
 
 // Forward declarations
 class UltrasonicSensorArray;
 class TofSensor;
-class LidarSensor;
 
 class SensorControl {
 public:

--- a/components/sensor_control/sensor_control.cpp
+++ b/components/sensor_control/sensor_control.cpp
@@ -2,6 +2,7 @@
 #include "sensor_control.hpp"
 #include "ultrasonic_sensor.hpp"
 #include "tof_sensor.hpp"
+#include "lidar_sensor.hpp"
 #include "sensor_common.hpp"
 #include "firmware_version.hpp"
 
@@ -98,6 +99,10 @@ esp_err_t SensorControl::initialize_tof() {
     }
 
     ESP_LOGI(TAG, "TOF sensors initialized successfully");
+#if SHELFBOT_HAS_LIDAR
+    lidar_sensor_ = std::make_unique<LidarSensor>(tof_sensor_.get());
+    ESP_LOGI(TAG, "LidarSensor initialized");
+#endif
     return ESP_OK;
 }
 
@@ -231,7 +236,7 @@ void SensorControl::continuous_read_loop() {
             }
 
             latest_data_.timestamp_us = timestamp;
-#if SHELFBOT_ENABLE_LIDAR
+#if SHELFBOT_HAS_LIDAR
             latest_data_.lidar_measurement.distance_mm = latest_data_.tof_measurements[0].distance_mm;
             latest_data_.lidar_measurement.valid = latest_data_.tof_measurements[0].valid;
             latest_data_.lidar_measurement.status = latest_data_.tof_measurements[0].status;

--- a/components/sensor_control/sensor_manager.cpp
+++ b/components/sensor_control/sensor_manager.cpp
@@ -74,7 +74,7 @@ void SensorManager::initialize(const SensorControl::Config& config) {
                     latest_data_.ultrasonic_readings[i].distance_cm = distances[i] / 10.0f;
                 }
                 latest_data_.timestamp_us = esp_timer_get_time();
-#if SHELFBOT_ENABLE_LIDAR
+#if SHELFBOT_HAS_LIDAR
                 latest_data_.lidar_measurement.distance_mm = latest_data_.tof_measurements[0].distance_mm;
                 latest_data_.lidar_measurement.valid = latest_data_.tof_measurements[0].valid;
                 latest_data_.lidar_measurement.status = latest_data_.tof_measurements[0].status;
@@ -93,7 +93,7 @@ void SensorManager::initialize(const SensorControl::Config& config) {
                     latest_data_.tof_measurements[i] = measurements[i];
                 }
                 latest_data_.timestamp_us = esp_timer_get_time();
-#if SHELFBOT_ENABLE_LIDAR
+#if SHELFBOT_HAS_LIDAR
                 latest_data_.lidar_measurement.distance_mm = latest_data_.tof_measurements[0].distance_mm;
                 latest_data_.lidar_measurement.valid = latest_data_.tof_measurements[0].valid;
                 latest_data_.lidar_measurement.status = latest_data_.tof_measurements[0].status;
@@ -127,7 +127,7 @@ void SensorManager::initialize(const SensorControl::Config& config) {
         latest_data_.tof_measurements[i] = SensorCommon::TofMeasurement();
     }
     latest_data_.timestamp_us = 0;
-#if SHELFBOT_ENABLE_LIDAR
+#if SHELFBOT_HAS_LIDAR
     latest_data_.lidar_measurement = SensorCommon::LidarMeasurement();
 #endif
 

--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -180,11 +180,11 @@ void Shelfbot::create_entities() {
     RCCHECK(rclc_subscription_init_default(&led_subscription, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool), "shelfbot_firmware/led"));
 
     // Timers
-    RCCHECK(rclc_timer_init_default2(&heartbeat_timer, &support, RCL_MS_TO_NS(1000), heartbeat_timer_callback_wrapper, true));
-    RCCHECK(rclc_timer_init_default2(&motor_position_timer, &support, RCL_MS_TO_NS(100), motor_position_timer_callback_wrapper, true));
-    RCCHECK(rclc_timer_init_default2(&distance_sensors_timer, &support, RCL_MS_TO_NS(200), distance_sensors_timer_callback_wrapper, true));
-    RCCHECK(rclc_timer_init_default2(&led_state_timer, &support, RCL_MS_TO_NS(2000), led_state_timer_callback_wrapper, true));
-    RCCHECK(rclc_timer_init_default2(&tof_timer, &support, RCL_MS_TO_NS(100), tof_timer_callback_wrapper, true));
+    RCCHECK(rclc_timer_init_default(&heartbeat_timer, &support, RCL_MS_TO_NS(1000), heartbeat_timer_callback_wrapper));
+    RCCHECK(rclc_timer_init_default(&motor_position_timer, &support, RCL_MS_TO_NS(100), motor_position_timer_callback_wrapper));
+    RCCHECK(rclc_timer_init_default(&distance_sensors_timer, &support, RCL_MS_TO_NS(200), distance_sensors_timer_callback_wrapper));
+    RCCHECK(rclc_timer_init_default(&led_state_timer, &support, RCL_MS_TO_NS(2000), led_state_timer_callback_wrapper));
+    RCCHECK(rclc_timer_init_default(&tof_timer, &support, RCL_MS_TO_NS(100), tof_timer_callback_wrapper));
 
     // Executor
     unsigned int num_handles = 5 + 3; // 5 timers + 3 subs


### PR DESCRIPTION
### Motivation
- Provide the same human-readable status text support for `LidarMeasurement` as exists for `TofMeasurement` so HTTP/JSON output can include lidar status strings.
- Standardize the feature macro name to `SHELFBOT_HAS_LIDAR` and ensure the `LidarSensor` is wired into sensor initialization and data flow when enabled.
- Update use of the rclc timer initializer to the simpler `rclc_timer_init_default` API for compatibility with the rclc version in use.

### Description
- Added `HttpServer::get_sensor_status_text(const SensorCommon::LidarMeasurement&)` implementation and declared it in `http_server.hpp` so lidar measurements can produce status text in JSON.
- Included `lidar_sensor.hpp` in sensor control headers/sources and instantiate `lidar_sensor_` in `SensorControl::initialize_tof()` under `#if SHELFBOT_HAS_LIDAR` so a Lidar manager is created when enabled.
- Replaced occurrences of `SHELFBOT_ENABLE_LIDAR` with `SHELFBOT_HAS_LIDAR` and copied TOF results into `latest_data_.lidar_measurement` where guarded by the new macro in `sensor_control.cpp` and `sensor_manager.cpp`.
- Replaced calls to `rclc_timer_init_default2` with `rclc_timer_init_default` in `shelfbot.cpp` to match the current rclc timer API.

### Testing
- Performed a full firmware build with `idf.py build` which completed successfully.
- Ran static checks (`cppcheck`/lint) on the modified files with no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78a4c05548322a9183c991d2b4f05)