### PR TITLE
Implement runtime LiDAR config and data flow in SensorControl

### DIFF
--- a/components/sensor_control/include/sensor_common.hpp
+++ b/components/sensor_control/include/sensor_common.hpp
@@ -19,7 +19,7 @@ namespace SensorCommon {
     bool active;          // Compile-time configured presence
     bool valid;           // Quick validity flag
 
-    Reading() : distance_cm(0.0f), status(0), timestamp_us(0), active(SHELFBOT_HAS_ULTRASONIC), valid(false) {}
+    Reading() : distance_cm(0.0f), status(0), timestamp_us(0), active(false), valid(false) {}
   };
 
   // ToF sensor data structure
@@ -31,7 +31,7 @@ namespace SensorCommon {
     int64_t timestamp_us;
     bool timeout_occurred;
 
-    TofMeasurement() : distance_mm(0), active(SHELFBOT_HAS_TOF), valid(false), status(0),
+    TofMeasurement() : distance_mm(0), active(false), valid(false), status(0),
                        timestamp_us(0), timeout_occurred(false) {}
 
     // Helper to get distance in cm
@@ -46,7 +46,7 @@ namespace SensorCommon {
     int64_t timestamp_us;
     bool timeout_occurred;
 
-    LidarMeasurement() : distance_mm(0), active(SHELFBOT_HAS_LIDAR), valid(false), status(0),
+    LidarMeasurement() : distance_mm(0), active(false), valid(false), status(0),
                          timestamp_us(0), timeout_occurred(false) {}
 
     float distance_cm() const { return distance_mm / 10.0f; }

--- a/components/sensor_control/include/sensor_control.hpp
+++ b/components/sensor_control/include/sensor_control.hpp
@@ -18,6 +18,14 @@ public:
     };
 
     struct Config {
+        enum class LidarDriverType : uint8_t {
+            NONE = 0,
+            LYDSTO,
+            VL53L0X,
+            VL53L1,
+            VL53L1_MODBUS
+        };
+
         // Ultrasonic sensors configuration
         std::vector<UltrasonicConfig> ultrasonic_configs;
 
@@ -29,6 +37,12 @@ public:
         };
 
         TofConfig tof_configs[SensorCommon::NUM_TOF_SENSORS];
+
+        struct LidarConfig {
+            bool enabled = false;
+            LidarDriverType driver = LidarDriverType::NONE;
+            uint8_t tof_sensor_index = 0;
+        } lidar_config;
 
         // Reading intervals
         uint32_t ultrasonic_read_interval_ms = 100;
@@ -96,6 +110,7 @@ private:
     // Internal helpers
     esp_err_t initialize_ultrasonic();
     esp_err_t initialize_tof();
+    esp_err_t update_lidar_measurement_from_tof();
 
     static const char* TAG;
 

--- a/components/sensor_control/lidar_sensor.cpp
+++ b/components/sensor_control/lidar_sensor.cpp
@@ -3,7 +3,7 @@ esp_err_t LidarSensor::read(SensorCommon::LidarMeasurement& out) {
   if (!tof_) return ESP_ERR_INVALID_STATE;
   SensorCommon::TofMeasurement m{};
   esp_err_t e = tof_->read_sensor(0, m);
-  out.active = SHELFBOT_HAS_LIDAR;
+  out.active = true;
   out.valid = (e == ESP_OK) && m.valid;
   out.distance_mm = m.distance_mm;
   out.status = m.status;

--- a/components/sensor_control/sensor_control.cpp
+++ b/components/sensor_control/sensor_control.cpp
@@ -99,10 +99,13 @@ esp_err_t SensorControl::initialize_tof() {
     }
 
     ESP_LOGI(TAG, "TOF sensors initialized successfully");
-#if SHELFBOT_HAS_LIDAR
-    lidar_sensor_ = std::make_unique<LidarSensor>(tof_sensor_.get());
-    ESP_LOGI(TAG, "LidarSensor initialized");
-#endif
+    if (config_.lidar_config.enabled) {
+        lidar_sensor_ = std::make_unique<LidarSensor>(tof_sensor_.get());
+        latest_data_.lidar_measurement.active = true;
+        ESP_LOGI(TAG, "LidarSensor initialized (driver=%d)", static_cast<int>(config_.lidar_config.driver));
+    } else {
+        latest_data_.lidar_measurement.active = false;
+    }
     return ESP_OK;
 }
 
@@ -134,6 +137,36 @@ esp_err_t SensorControl::initialize() {
     ESP_LOGI(TAG, "Sensor Control Initialization Complete");
     ESP_LOGI(TAG, "=========================================");
 
+    for (int i = 0; i < SensorCommon::NUM_ULTRASONIC_SENSORS; i++) {
+        latest_data_.ultrasonic_readings[i].active = (i < static_cast<int>(config_.ultrasonic_configs.size()));
+    }
+    for (int i = 0; i < SensorCommon::NUM_TOF_SENSORS; i++) {
+        latest_data_.tof_measurements[i].active = config_.tof_configs[i].enabled;
+    }
+    latest_data_.lidar_measurement.active = config_.lidar_config.enabled;
+
+    return ESP_OK;
+}
+
+esp_err_t SensorControl::update_lidar_measurement_from_tof() {
+    latest_data_.lidar_measurement.active = config_.lidar_config.enabled;
+    if (!config_.lidar_config.enabled) {
+        latest_data_.lidar_measurement.valid = false;
+        latest_data_.lidar_measurement.status = 0;
+        return ESP_OK;
+    }
+
+    uint8_t idx = config_.lidar_config.tof_sensor_index;
+    if (idx >= SensorCommon::NUM_TOF_SENSORS) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const auto& tof = latest_data_.tof_measurements[idx];
+    latest_data_.lidar_measurement.distance_mm = tof.distance_mm;
+    latest_data_.lidar_measurement.valid = tof.valid;
+    latest_data_.lidar_measurement.status = tof.status;
+    latest_data_.lidar_measurement.timestamp_us = tof.timestamp_us;
+    latest_data_.lidar_measurement.timeout_occurred = tof.timeout_occurred;
     return ESP_OK;
 }
 
@@ -236,13 +269,7 @@ void SensorControl::continuous_read_loop() {
             }
 
             latest_data_.timestamp_us = timestamp;
-#if SHELFBOT_HAS_LIDAR
-            latest_data_.lidar_measurement.distance_mm = latest_data_.tof_measurements[0].distance_mm;
-            latest_data_.lidar_measurement.valid = latest_data_.tof_measurements[0].valid;
-            latest_data_.lidar_measurement.status = latest_data_.tof_measurements[0].status;
-            latest_data_.lidar_measurement.timestamp_us = latest_data_.tof_measurements[0].timestamp_us;
-            latest_data_.lidar_measurement.timeout_occurred = latest_data_.tof_measurements[0].timeout_occurred;
-#endif
+            update_lidar_measurement_from_tof();
 
             xSemaphoreGive(data_mutex_);
 

--- a/components/sensor_control/sensor_manager.cpp
+++ b/components/sensor_control/sensor_manager.cpp
@@ -74,13 +74,11 @@ void SensorManager::initialize(const SensorControl::Config& config) {
                     latest_data_.ultrasonic_readings[i].distance_cm = distances[i] / 10.0f;
                 }
                 latest_data_.timestamp_us = esp_timer_get_time();
-#if SHELFBOT_HAS_LIDAR
                 latest_data_.lidar_measurement.distance_mm = latest_data_.tof_measurements[0].distance_mm;
-                latest_data_.lidar_measurement.valid = latest_data_.tof_measurements[0].valid;
+                latest_data_.lidar_measurement.valid = latest_data_.lidar_measurement.active && latest_data_.tof_measurements[0].valid;
                 latest_data_.lidar_measurement.status = latest_data_.tof_measurements[0].status;
                 latest_data_.lidar_measurement.timestamp_us = latest_data_.tof_measurements[0].timestamp_us;
                 latest_data_.lidar_measurement.timeout_occurred = latest_data_.tof_measurements[0].timeout_occurred;
-#endif
                 xSemaphoreGive(data_mutex_);
             }
         };
@@ -93,13 +91,11 @@ void SensorManager::initialize(const SensorControl::Config& config) {
                     latest_data_.tof_measurements[i] = measurements[i];
                 }
                 latest_data_.timestamp_us = esp_timer_get_time();
-#if SHELFBOT_HAS_LIDAR
                 latest_data_.lidar_measurement.distance_mm = latest_data_.tof_measurements[0].distance_mm;
-                latest_data_.lidar_measurement.valid = latest_data_.tof_measurements[0].valid;
+                latest_data_.lidar_measurement.valid = latest_data_.lidar_measurement.active && latest_data_.tof_measurements[0].valid;
                 latest_data_.lidar_measurement.status = latest_data_.tof_measurements[0].status;
                 latest_data_.lidar_measurement.timestamp_us = latest_data_.tof_measurements[0].timestamp_us;
                 latest_data_.lidar_measurement.timeout_occurred = latest_data_.tof_measurements[0].timeout_occurred;
-#endif
                 xSemaphoreGive(data_mutex_);
             }
         };
@@ -125,11 +121,11 @@ void SensorManager::initialize(const SensorControl::Config& config) {
     }
     for (int i = 0; i < SensorCommon::NUM_TOF_SENSORS; i++) {
         latest_data_.tof_measurements[i] = SensorCommon::TofMeasurement();
+        latest_data_.tof_measurements[i].active = config.tof_configs[i].enabled;
     }
     latest_data_.timestamp_us = 0;
-#if SHELFBOT_HAS_LIDAR
     latest_data_.lidar_measurement = SensorCommon::LidarMeasurement();
-#endif
+    latest_data_.lidar_measurement.active = config.lidar_config.enabled;
 
     initialized_ = true;
     ESP_LOGI(TAG, "SensorManager initialized successfully");


### PR DESCRIPTION
### Motivation
- Replace compile-time LiDAR presence macros with runtime-configurable structures so sensor activation and driver selection are controlled from `SensorControl::Config` instead of `#define` constants.
- Ensure the sensor-control loop consistently produces a LiDAR measurement by deriving it from a configured ToF source index and keeping per-device active flags in the shared data packet.

### Description
- Added `LidarDriverType` enum and `LidarConfig` (with `enabled`, `driver`, `tof_sensor_index`) to `SensorControl::Config` to represent LiDAR runtime configuration (`components/sensor_control/include/sensor_control.hpp`).
- Introduced `update_lidar_measurement_from_tof()` and wired it into the continuous read loop so LiDAR fields are populated from the selected ToF index each cycle (`components/sensor_control/sensor_control.cpp`).
- Switched sensor `active` defaults in `SensorCommon` structs to `false` and set `active` flags at runtime for ultrasonic, ToF and LiDAR from the `Config` during initialization (`components/sensor_control/include/sensor_common.hpp`, `components/sensor_control/sensor_control.cpp`, `components/sensor_control/sensor_manager.cpp`).
- Removed compile-time `#if SHELFBOT_HAS_LIDAR` gating in manager/control synchronization and updated callbacks to compute LiDAR validity using the runtime `lidar_measurement.active` flag; updated `LidarSensor::read` to mark `out.active = true` when invoked (`components/sensor_control/sensor_manager.cpp`, `components/sensor_control/lidar_sensor.cpp`).

### Testing
- Attempted to run the ESP-IDF build using `idf.py build` but the environment does not have the ESP-IDF CLI installed, so the build could not be executed (`idf.py: command not found`).
- Performed static verification of source edits by grepping and listing updated files to confirm the new symbols and helper were integrated; no automated unit/integration tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7abca338c83228e2442b47c0a0b2c)