### PR TITLE
Enable LYDSTO LiDAR and add UART diagnostics

### DIFF
--- a/components/lydsto_driver/include/lydsto.hpp
+++ b/components/lydsto_driver/include/lydsto.hpp
@@ -18,7 +18,10 @@ public:
         int64_t  timestamp_us;
     };
 
-    LYDSTO_Driver();
+    LYDSTO_Driver(uart_port_t uart_port = LYDSTO_UART_PORT,
+                  int uart_tx_pin = LYDSTO_TX_PIN,
+                  int uart_rx_pin = LYDSTO_RX_PIN,
+                  uint32_t baud_rate = LYDSTO_BAUD_RATE);
     ~LYDSTO_Driver();
 
     const char* configure();

--- a/components/lydsto_driver/lydsto.cpp
+++ b/components/lydsto_driver/lydsto.cpp
@@ -2,9 +2,9 @@
 
 static const char* TAG = "TofDriver_LYDSTO";
 
-LYDSTO_Driver::LYDSTO_Driver()
-    : uart_port_(LYDSTO_UART_PORT), uart_tx_pin_(LYDSTO_TX_PIN), uart_rx_pin_(LYDSTO_RX_PIN),
-      baud_rate_(LYDSTO_BAUD_RATE), timeout_ms_(LYDSTO_TIMEOUT_MS),
+LYDSTO_Driver::LYDSTO_Driver(uart_port_t uart_port, int uart_tx_pin, int uart_rx_pin, uint32_t baud_rate)
+    : uart_port_(uart_port), uart_tx_pin_(uart_tx_pin), uart_rx_pin_(uart_rx_pin),
+      baud_rate_(baud_rate), timeout_ms_(LYDSTO_TIMEOUT_MS),
       initialized_(false), timeout_occurred_(false) {}
 
 LYDSTO_Driver::~LYDSTO_Driver() {
@@ -14,6 +14,8 @@ LYDSTO_Driver::~LYDSTO_Driver() {
 const char* LYDSTO_Driver::configure() { return nullptr; }
 
 const char* LYDSTO_Driver::init() {
+    ESP_LOGI(TAG, "UART init start (UART=%d RX=%d TX=%d BAUD=%lu)",
+             static_cast<int>(uart_port_), uart_rx_pin_, uart_tx_pin_, static_cast<unsigned long>(baud_rate_));
     uart_config_t cfg{};
     cfg.baud_rate = baud_rate_;
     cfg.data_bits = UART_DATA_8_BITS;
@@ -23,7 +25,9 @@ const char* LYDSTO_Driver::init() {
     if (uart_param_config(uart_port_, &cfg) != ESP_OK) return "uart_param_config failed";
     if (uart_set_pin(uart_port_, uart_tx_pin_, uart_rx_pin_, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE) != ESP_OK) return "uart_set_pin failed";
     if (uart_driver_install(uart_port_, 4096, 0, 0, nullptr, 0) != ESP_OK) return "uart_driver_install failed";
+    uart_flush_input(uart_port_);
     initialized_ = true;
+    ESP_LOGI(TAG, "UART init done");
     return nullptr;
 }
 
@@ -79,6 +83,10 @@ bool LYDSTO_Driver::read_sensor(MeasurementResult& result) {
     result.timestamp_us = esp_timer_get_time();
     uint8_t p[PACKET_LEN];
     if (!readPacket(p) || !validPacket(p)) {
+        size_t buffered = 0;
+        uart_get_buffered_data_len(uart_port_, &buffered);
+        ESP_LOGW(TAG, "read_sensor failed (timeout=%d buffered=%u)",
+                 static_cast<int>(timeout_occurred_), static_cast<unsigned>(buffered));
         result.valid = false;
         result.timeout_occurred = timeout_occurred_;
         result.range_status = 1;

--- a/components/sensor_control/include/lidar_sensor.hpp
+++ b/components/sensor_control/include/lidar_sensor.hpp
@@ -12,4 +12,8 @@ public:
 private:
   LYDSTO_Driver driver_;
   bool initialized_;
+  uart_port_t uart_port_;
+  int tx_pin_;
+  int rx_pin_;
+  uint32_t baud_rate_;
 };

--- a/components/sensor_control/lidar_sensor.cpp
+++ b/components/sensor_control/lidar_sensor.cpp
@@ -1,15 +1,16 @@
 #include "lidar_sensor.hpp"
 LidarSensor::LidarSensor(const uart_port_t uart_port, int tx_pin, int rx_pin, uint32_t baud_rate)
-    : driver_(), initialized_(false) {
-  (void)uart_port;
-  (void)tx_pin;
-  (void)rx_pin;
-  (void)baud_rate;
-}
+    : driver_(uart_port, tx_pin, rx_pin, baud_rate), initialized_(false),
+      uart_port_(uart_port), tx_pin_(tx_pin), rx_pin_(rx_pin), baud_rate_(baud_rate) {}
 
 esp_err_t LidarSensor::initialize() {
+  ESP_LOGI("LidarSensor", "Initializing LYDSTO (UART=%d RX=%d TX=%d BAUD=%lu)",
+           static_cast<int>(uart_port_), rx_pin_, tx_pin_, static_cast<unsigned long>(baud_rate_));
   const char* err = driver_.init();
   initialized_ = (err == nullptr);
+  if (!initialized_) {
+    ESP_LOGE("LidarSensor", "LYDSTO init failed: %s", err ? err : "unknown error");
+  }
   return initialized_ ? ESP_OK : ESP_FAIL;
 }
 
@@ -24,5 +25,10 @@ esp_err_t LidarSensor::read(SensorCommon::LidarMeasurement& out) {
   out.timestamp_us = m.timestamp_us;
   out.timeout_occurred = m.timeout_occurred;
   out.health = out.valid ? 1 : 2;
+  if (!ok) {
+    ESP_LOGW("LidarSensor", "Read failed (timeout=%d status=%u valid=%d dist=%u)",
+             static_cast<int>(m.timeout_occurred), static_cast<unsigned>(m.range_status),
+             static_cast<int>(m.valid), static_cast<unsigned>(m.distance_mm));
+  }
   return ok ? ESP_OK : ESP_FAIL;
 }

--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -360,6 +360,13 @@ void Shelfbot::begin() {
     sensor_config.ultrasonic_read_interval_ms = 100;
     sensor_config.tof_read_interval_ms = 200;
 
+    // Configure LYDSTO LiDAR over UART (RX on GPIO3)
+    sensor_config.lidar_config.enabled = true;
+    sensor_config.lidar_config.uart_port = UART_NUM_2;
+    sensor_config.lidar_config.uart_tx_pin = UART_PIN_NO_CHANGE;
+    sensor_config.lidar_config.uart_rx_pin = GPIO_NUM_3;
+    sensor_config.lidar_config.baud_rate = 115200;
+
     // Initialize the global sensor manager
     SensorManager::get_instance().initialize(sensor_config);
     SensorManager::get_instance().start();


### PR DESCRIPTION
### Motivation
- The LiDAR driver was never being invoked because LiDAR was disabled in the runtime sensor configuration, and the `LidarSensor` constructor ignored the runtime UART/pin/baud arguments so the driver used hardcoded defaults.
- Add runtime wiring and diagnostics so the LYDSTO driver can be exercised and problems (timeouts, buffered bytes, init failures) can be observed in logs.

### Description
- Enable LiDAR in the startup `SensorControl::Config` and set UART2 RX to `GPIO3` at `115200` in `components/shelfbot/shelfbot.cpp` so the LiDAR initialization path is executed at boot.
- Make `LidarSensor` store and forward the configured UART parameters and log the effective UART configuration on initialization in `components/sensor_control/lidar_sensor.cpp` and its header.
- Change `LYDSTO_Driver` to accept runtime `uart_port`, `tx_pin`, `rx_pin`, and `baud_rate` (defaults preserved) and log UART init start/done in `components/lydsto_driver/lydsto.cpp` and its header.
- Add diagnostics on read failures: flush input on init, log buffered bytes and timeout state when `read_sensor` fails, and log read failure details from `LidarSensor` to aid correlation with oscilloscope traces.

### Testing
- Ran `git status --short` and created a commit for the changes which succeeded (`git commit` returned success).
- Attempted to run a full build with `idf.py build` but the environment does not have `idf.py` installed, so the build could not be executed here (failure).
- All source-level changes are consistent across headers/constructors and were committed; runtime verification should be done on-device to confirm UART init logs and subsequent read diagnostics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90da32e188322a25cebc624de5a76)