### PR TITLE
Improve LYDSTO UART parsing, add diagnostics, expose UART params, and adjust sensor init logic

### DIFF
--- a/components/lydsto_driver/include/lydsto.hpp
+++ b/components/lydsto_driver/include/lydsto.hpp
@@ -18,7 +18,10 @@ public:
         int64_t  timestamp_us;
     };
 
-    LYDSTO_Driver();
+    LYDSTO_Driver(uart_port_t uart_port = LYDSTO_UART_PORT,
+                  int uart_tx_pin = LYDSTO_TX_PIN,
+                  int uart_rx_pin = LYDSTO_RX_PIN,
+                  uint32_t baud_rate = LYDSTO_BAUD_RATE);
     ~LYDSTO_Driver();
 
     const char* configure();
@@ -48,10 +51,14 @@ private:
 
     bool initialized_;
     bool timeout_occurred_;
+    uint8_t parser_buf_[512];
+    size_t parser_len_;
+    uint32_t total_rx_bytes_;
+    uint32_t header_fa_hits_;
+    uint32_t valid_packets_;
+    uint32_t failed_reads_;
 
     bool readPacket(uint8_t* packet);
     bool validPacket(const uint8_t* packet) const;
     bool extractMinDistance(const uint8_t* packet, uint16_t& min_mm) const;
 };
-
-using TofDriver = LYDSTO_Driver;

--- a/components/lydsto_driver/lydsto.cpp
+++ b/components/lydsto_driver/lydsto.cpp
@@ -2,10 +2,23 @@
 
 static const char* TAG = "TofDriver_LYDSTO";
 
-LYDSTO_Driver::LYDSTO_Driver()
-    : uart_port_(LYDSTO_UART_PORT), uart_tx_pin_(LYDSTO_TX_PIN), uart_rx_pin_(LYDSTO_RX_PIN),
-      baud_rate_(LYDSTO_BAUD_RATE), timeout_ms_(LYDSTO_TIMEOUT_MS),
-      initialized_(false), timeout_occurred_(false) {}
+static void log_hex_preview(const char* prefix, const uint8_t* data, size_t len) {
+    char line[3 * 24 + 1] = {0};
+    size_t n = (len < 24) ? len : 24;
+    size_t off = 0;
+    for (size_t i = 0; i < n && off + 4 < sizeof(line); ++i) {
+        int wrote = snprintf(line + off, sizeof(line) - off, "%02X ", data[i]);
+        if (wrote <= 0) break;
+        off += static_cast<size_t>(wrote);
+    }
+    ESP_LOGW(TAG, "%s (%uB): %s", prefix, static_cast<unsigned>(len), line);
+}
+
+LYDSTO_Driver::LYDSTO_Driver(uart_port_t uart_port, int uart_tx_pin, int uart_rx_pin, uint32_t baud_rate)
+    : uart_port_(uart_port), uart_tx_pin_(uart_tx_pin), uart_rx_pin_(uart_rx_pin),
+      baud_rate_(baud_rate), timeout_ms_(LYDSTO_TIMEOUT_MS),
+      initialized_(false), timeout_occurred_(false), parser_len_(0),
+      total_rx_bytes_(0), header_fa_hits_(0), valid_packets_(0), failed_reads_(0) {}
 
 LYDSTO_Driver::~LYDSTO_Driver() {
     uart_driver_delete(uart_port_);
@@ -14,6 +27,8 @@ LYDSTO_Driver::~LYDSTO_Driver() {
 const char* LYDSTO_Driver::configure() { return nullptr; }
 
 const char* LYDSTO_Driver::init() {
+    ESP_LOGI(TAG, "UART init start (UART=%d RX=%d TX=%d BAUD=%lu)",
+             static_cast<int>(uart_port_), uart_rx_pin_, uart_tx_pin_, static_cast<unsigned long>(baud_rate_));
     uart_config_t cfg{};
     cfg.baud_rate = baud_rate_;
     cfg.data_bits = UART_DATA_8_BITS;
@@ -23,7 +38,9 @@ const char* LYDSTO_Driver::init() {
     if (uart_param_config(uart_port_, &cfg) != ESP_OK) return "uart_param_config failed";
     if (uart_set_pin(uart_port_, uart_tx_pin_, uart_rx_pin_, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE) != ESP_OK) return "uart_set_pin failed";
     if (uart_driver_install(uart_port_, 4096, 0, 0, nullptr, 0) != ESP_OK) return "uart_driver_install failed";
+    uart_flush_input(uart_port_);
     initialized_ = true;
+    ESP_LOGI(TAG, "UART init done");
     return nullptr;
 }
 
@@ -62,12 +79,42 @@ bool LYDSTO_Driver::extractMinDistance(const uint8_t* p, uint16_t& min_mm) const
 bool LYDSTO_Driver::readPacket(uint8_t* packet) {
     timeout_occurred_ = false;
     int64_t deadline = esp_timer_get_time() + static_cast<int64_t>(timeout_ms_) * 1000;
-    uint8_t b;
+    uint8_t rx_tmp[128];
+    static int sample_log_budget = 8;
     while (esp_timer_get_time() < deadline) {
-        if (uart_read_bytes(uart_port_, &b, 1, pdMS_TO_TICKS(20)) == 1 && b == COMMAND) {
-            packet[0] = b;
-            int n = uart_read_bytes(uart_port_, packet + 1, PACKET_LEN - 1, pdMS_TO_TICKS(timeout_ms_));
-            if (n == PACKET_LEN - 1) return true;
+        int n = uart_read_bytes(uart_port_, rx_tmp, sizeof(rx_tmp), pdMS_TO_TICKS(20));
+        if (n > 0) {
+            total_rx_bytes_ += static_cast<uint32_t>(n);
+            for (int i = 0; i < n; ++i) {
+                if (rx_tmp[i] == COMMAND) header_fa_hits_++;
+            }
+            if (sample_log_budget > 0) {
+                log_hex_preview("RX chunk", rx_tmp, static_cast<size_t>(n));
+                sample_log_budget--;
+            }
+            size_t space = sizeof(parser_buf_) - parser_len_;
+            size_t copy_n = (static_cast<size_t>(n) < space) ? static_cast<size_t>(n) : space;
+            memcpy(parser_buf_ + parser_len_, rx_tmp, copy_n);
+            parser_len_ += copy_n;
+
+            for (size_t i = 0; i + PACKET_LEN <= parser_len_; ++i) {
+                if (parser_buf_[i] != COMMAND) continue;
+                if (validPacket(parser_buf_ + i)) {
+                    log_hex_preview("Valid packet", parser_buf_ + i, PACKET_LEN);
+                    memcpy(packet, parser_buf_ + i, PACKET_LEN);
+                    valid_packets_++;
+                    size_t remain = parser_len_ - (i + PACKET_LEN);
+                    memmove(parser_buf_, parser_buf_ + i + PACKET_LEN, remain);
+                    parser_len_ = remain;
+                    return true;
+                }
+            }
+
+            if (parser_len_ > PACKET_LEN) {
+                size_t keep = PACKET_LEN - 1;
+                memmove(parser_buf_, parser_buf_ + (parser_len_ - keep), keep);
+                parser_len_ = keep;
+            }
         }
     }
     timeout_occurred_ = true;
@@ -79,6 +126,27 @@ bool LYDSTO_Driver::read_sensor(MeasurementResult& result) {
     result.timestamp_us = esp_timer_get_time();
     uint8_t p[PACKET_LEN];
     if (!readPacket(p) || !validPacket(p)) {
+        failed_reads_++;
+        size_t buffered = 0;
+        uart_get_buffered_data_len(uart_port_, &buffered);
+        ESP_LOGW(TAG, "read_sensor failed (timeout=%d buffered=%u)",
+                 static_cast<int>(timeout_occurred_), static_cast<unsigned>(buffered));
+        if ((failed_reads_ % 20) == 0) {
+            ESP_LOGW(TAG,
+                     "RX stats: bytes=%lu fa_headers=%lu valid_packets=%lu failed_reads=%lu",
+                     static_cast<unsigned long>(total_rx_bytes_),
+                     static_cast<unsigned long>(header_fa_hits_),
+                     static_cast<unsigned long>(valid_packets_),
+                     static_cast<unsigned long>(failed_reads_));
+        }
+        if (parser_len_ > 0) {
+            log_hex_preview("Parser tail", parser_buf_, parser_len_);
+        }
+        if (buffered > 1024) {
+            ESP_LOGW(TAG, "input backlog detected, flushing UART RX buffer");
+            uart_flush_input(uart_port_);
+            parser_len_ = 0;
+        }
         result.valid = false;
         result.timeout_occurred = timeout_occurred_;
         result.range_status = 1;

--- a/components/sensor_control/include/lidar_sensor.hpp
+++ b/components/sensor_control/include/lidar_sensor.hpp
@@ -12,4 +12,8 @@ public:
 private:
   LYDSTO_Driver driver_;
   bool initialized_;
+  uart_port_t uart_port_;
+  int tx_pin_;
+  int rx_pin_;
+  uint32_t baud_rate_;
 };

--- a/components/sensor_control/include/sensor_control.h
+++ b/components/sensor_control/include/sensor_control.h
@@ -2,11 +2,11 @@
 
 // Centralized compile-time sensor presence
 #define SHELFBOT_HAS_ULTRASONIC 1
-#define SHELFBOT_HAS_TOF 1
+#define SHELFBOT_HAS_TOF 0
 #define SHELFBOT_HAS_LIDAR 1
 
 // Centralized ToF/LiDAR driver selection (choose exactly one)
 #define SHELFBOT_DRIVER_VL53L0X 0
 #define SHELFBOT_DRIVER_VL53L1 0
-#define SHELFBOT_DRIVER_VL53L1_MODBUS 0
-#define SHELFBOT_DRIVER_LYDSTO 1
+#define SHELFBOT_DRIVER_VL53L1_MODBUS 1
+#define SHELFBOT_DRIVER_LYDSTO 0

--- a/components/sensor_control/lidar_sensor.cpp
+++ b/components/sensor_control/lidar_sensor.cpp
@@ -1,15 +1,16 @@
 #include "lidar_sensor.hpp"
 LidarSensor::LidarSensor(const uart_port_t uart_port, int tx_pin, int rx_pin, uint32_t baud_rate)
-    : driver_(), initialized_(false) {
-  (void)uart_port;
-  (void)tx_pin;
-  (void)rx_pin;
-  (void)baud_rate;
-}
+    : driver_(uart_port, tx_pin, rx_pin, baud_rate), initialized_(false),
+      uart_port_(uart_port), tx_pin_(tx_pin), rx_pin_(rx_pin), baud_rate_(baud_rate) {}
 
 esp_err_t LidarSensor::initialize() {
+  ESP_LOGI("LidarSensor", "Initializing LYDSTO (UART=%d RX=%d TX=%d BAUD=%lu)",
+           static_cast<int>(uart_port_), rx_pin_, tx_pin_, static_cast<unsigned long>(baud_rate_));
   const char* err = driver_.init();
   initialized_ = (err == nullptr);
+  if (!initialized_) {
+    ESP_LOGE("LidarSensor", "LYDSTO init failed: %s", err ? err : "unknown error");
+  }
   return initialized_ ? ESP_OK : ESP_FAIL;
 }
 
@@ -24,5 +25,10 @@ esp_err_t LidarSensor::read(SensorCommon::LidarMeasurement& out) {
   out.timestamp_us = m.timestamp_us;
   out.timeout_occurred = m.timeout_occurred;
   out.health = out.valid ? 1 : 2;
+  if (!ok) {
+    ESP_LOGW("LidarSensor", "Read failed (timeout=%d status=%u valid=%d dist=%u)",
+             static_cast<int>(m.timeout_occurred), static_cast<unsigned>(m.range_status),
+             static_cast<int>(m.valid), static_cast<unsigned>(m.distance_mm));
+  }
   return ok ? ESP_OK : ESP_FAIL;
 }

--- a/components/sensor_control/sensor_control.cpp
+++ b/components/sensor_control/sensor_control.cpp
@@ -100,15 +100,25 @@ esp_err_t SensorControl::initialize_tof() {
 
     ESP_LOGI(TAG, "TOF sensors initialized successfully");
     if (config_.lidar_config.enabled) {
+#if SHELFBOT_DRIVER_LYDSTO
+        ESP_LOGW(TAG, "LiDAR is enabled, but SHELFBOT_DRIVER_LYDSTO already uses UART LYDSTO as the ToF driver.");
+        ESP_LOGW(TAG, "Skipping separate LidarSensor init to avoid double-installing UART driver on same peripheral.");
+        latest_data_.lidar_measurement.active = false;
+        latest_data_.lidar_measurement.valid = false;
+        latest_data_.lidar_measurement.health = 3; // conflict/misconfiguration
+#else
         lidar_sensor_ = std::make_unique<LidarSensor>(
             static_cast<uart_port_t>(config_.lidar_config.uart_port),
             config_.lidar_config.uart_tx_pin,
             config_.lidar_config.uart_rx_pin,
             config_.lidar_config.baud_rate);
         if (lidar_sensor_->initialize() != ESP_OK) {
-            ESP_LOGE(TAG, "Lidar UART init failed");
+            ESP_LOGW(TAG, "Lidar UART init failed; continuing without LiDAR");
             lidar_sensor_.reset();
-            return ESP_FAIL;
+            latest_data_.lidar_measurement.active = false;
+            latest_data_.lidar_measurement.valid = false;
+            latest_data_.lidar_measurement.health = 2;
+            return ESP_OK;
         }
         latest_data_.lidar_measurement.active = true;
         ESP_LOGI(TAG, "LidarSensor initialized (UART=%d RX=%d TX=%d BAUD=%lu)",
@@ -116,6 +126,7 @@ esp_err_t SensorControl::initialize_tof() {
                  config_.lidar_config.uart_rx_pin,
                  config_.lidar_config.uart_tx_pin,
                  static_cast<unsigned long>(config_.lidar_config.baud_rate));
+#endif
     } else {
         latest_data_.lidar_measurement.active = false;
     }
@@ -138,11 +149,15 @@ esp_err_t SensorControl::initialize() {
         return err;
     }
 
+#if SHELFBOT_HAS_TOF
     err = initialize_tof();
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "TOF initialization failed");
         ESP_LOGW(TAG, "Continuing without TOF sensors");
     }
+#else
+    ESP_LOGW(TAG, "TOF category disabled at compile-time (SHELFBOT_HAS_TOF=0)");
+#endif
 
     initialized_ = true;
 
@@ -275,11 +290,13 @@ void SensorControl::continuous_read_loop() {
 
             // Read ToF sensors
             SensorCommon::TofMeasurement tof_results[SensorCommon::NUM_TOF_SENSORS];
+#if SHELFBOT_HAS_TOF
             if (tof_sensor_ && tof_sensor_->read_all(tof_results) == ESP_OK) {
                 for (int i = 0; i < SensorCommon::NUM_TOF_SENSORS; i++) {
                     latest_data_.tof_measurements[i] = tof_results[i];
                 }
             }
+#endif
 
             latest_data_.timestamp_us = timestamp;
             update_lidar_measurement();

--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -352,13 +352,21 @@ void Shelfbot::begin() {
         {.trig_pin = 32, .echo_pin = 33, .timeout_us = 30000, .max_distance_mm = 4000}
     };
 
-    // Configure 3 ToF sensors
+    // Configure ToF sensors (disabled: no ToF devices connected)
     for (int i = 0; i < SensorCommon::NUM_TOF_SENSORS; i++) {
         sensor_config.tof_configs[i].timeout_ms = 500;
+        sensor_config.tof_configs[i].enabled = false;
     }
 
     sensor_config.ultrasonic_read_interval_ms = 100;
     sensor_config.tof_read_interval_ms = 200;
+
+    // Configure LYDSTO LiDAR over UART (RX on GPIO3)
+    sensor_config.lidar_config.enabled = true;
+    sensor_config.lidar_config.uart_port = UART_NUM_2;
+    sensor_config.lidar_config.uart_tx_pin = UART_PIN_NO_CHANGE;
+    sensor_config.lidar_config.uart_rx_pin = GPIO_NUM_3;
+    sensor_config.lidar_config.baud_rate = 115200;
 
     // Initialize the global sensor manager
     SensorManager::get_instance().initialize(sensor_config);


### PR DESCRIPTION
### Motivation
- Improve robustness and diagnostics of the LYDSTO LDS02RR UART driver to handle fragmented UART reads and intermittent timeouts. 
- Allow configuration of UART port/pins/baud for the LiDAR driver and surface internal RX parsing statistics for troubleshooting. 
- Prevent double-installation of the same UART peripheral and harmonize sensor configuration when no ToF hardware is present. 

### Description
- Updated `LYDSTO_Driver` to accept constructor parameters `uart_port_t uart_port`, `int uart_tx_pin`, `int uart_rx_pin`, and `uint32_t baud_rate`, and added internal parser buffer, parsing state and RX statistics fields in `lydsto.hpp`.
- Reworked `readPacket` in `lydsto.cpp` to read chunks into an internal `parser_buf_`, scan for `COMMAND` headers, validate packets with `validPacket`, return the first valid aligned packet, and keep leftover tail bytes; added `log_hex_preview` helper and additional logging, UART flush on init, and RX backlog handling.
- Added diagnostics counters (`total_rx_bytes_`, `header_fa_hits_`, `valid_packets_`, `failed_reads_`) and periodic logging on read failures to aid debugging of noisy/framed serial data.
- Changed `LidarSensor` to forward UART parameters to `LYDSTO_Driver`, retain those params for logging, and emit warnings on initialization or read failures.
- Tweaked build-time sensor flags in `sensor_control.h` to disable the generic TOF category (`SHELFBOT_HAS_TOF=0`) and flip ToF driver selection to `VL53L1_MODBUS`, and added conditional logic in `SensorControl` to avoid creating a separate `LidarSensor` when `SHELFBOT_DRIVER_LYDSTO` is used, plus conditional compilation around TOF initialization and read loops.
- Updated `shelfbot.cpp` to mark ToF sensors as disabled in the default config and to enable and configure the LYDSTO LiDAR over UART (RX on `GPIO3`, `UART_NUM_2`, 115200 baud).

### Testing
- Built the full firmware with `idf.py build` and produced a firmware image successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90da32e188322a25cebc624de5a76)