### PR TITLE
LYDSTO: add robust UART parser, configurable constructor, and SensorControl LiDAR integration

### DIFF
--- a/components/lydsto_driver/include/lydsto.hpp
+++ b/components/lydsto_driver/include/lydsto.hpp
@@ -18,7 +18,10 @@ public:
         int64_t  timestamp_us;
     };
 
-    LYDSTO_Driver();
+    LYDSTO_Driver(uart_port_t uart_port = LYDSTO_UART_PORT,
+                  int uart_tx_pin = LYDSTO_TX_PIN,
+                  int uart_rx_pin = LYDSTO_RX_PIN,
+                  uint32_t baud_rate = LYDSTO_BAUD_RATE);
     ~LYDSTO_Driver();
 
     const char* configure();
@@ -36,9 +39,9 @@ public:
     LYDSTO_Driver& operator=(const LYDSTO_Driver&) = delete;
 
 private:
-    static constexpr uint8_t PACKET_LEN = 22;
-    static constexpr uint8_t COMMAND = 0xFA;
-    static constexpr uint8_t INDEX_LO = 0xA0;
+    static constexpr uint8_t PACKET_LEN = 47;
+    static constexpr uint8_t COMMAND = 0x54;
+    static constexpr uint8_t LENGTH_BYTE = 0x2C;
 
     uart_port_t uart_port_;
     int uart_tx_pin_;
@@ -48,10 +51,14 @@ private:
 
     bool initialized_;
     bool timeout_occurred_;
+    uint8_t parser_buf_[512];
+    size_t parser_len_;
+    uint32_t total_rx_bytes_;
+    uint32_t header_fa_hits_;
+    uint32_t valid_packets_;
+    uint32_t failed_reads_;
 
     bool readPacket(uint8_t* packet);
     bool validPacket(const uint8_t* packet) const;
     bool extractMinDistance(const uint8_t* packet, uint16_t& min_mm) const;
 };
-
-using TofDriver = LYDSTO_Driver;

--- a/components/lydsto_driver/lydsto.cpp
+++ b/components/lydsto_driver/lydsto.cpp
@@ -2,10 +2,23 @@
 
 static const char* TAG = "TofDriver_LYDSTO";
 
-LYDSTO_Driver::LYDSTO_Driver()
-    : uart_port_(LYDSTO_UART_PORT), uart_tx_pin_(LYDSTO_TX_PIN), uart_rx_pin_(LYDSTO_RX_PIN),
-      baud_rate_(LYDSTO_BAUD_RATE), timeout_ms_(LYDSTO_TIMEOUT_MS),
-      initialized_(false), timeout_occurred_(false) {}
+static void log_hex_preview(const char* prefix, const uint8_t* data, size_t len) {
+    char line[3 * 24 + 1] = {0};
+    size_t n = (len < 24) ? len : 24;
+    size_t off = 0;
+    for (size_t i = 0; i < n && off + 4 < sizeof(line); ++i) {
+        int wrote = snprintf(line + off, sizeof(line) - off, "%02X ", data[i]);
+        if (wrote <= 0) break;
+        off += static_cast<size_t>(wrote);
+    }
+    ESP_LOGW(TAG, "%s (%uB): %s", prefix, static_cast<unsigned>(len), line);
+}
+
+LYDSTO_Driver::LYDSTO_Driver(uart_port_t uart_port, int uart_tx_pin, int uart_rx_pin, uint32_t baud_rate)
+    : uart_port_(uart_port), uart_tx_pin_(uart_tx_pin), uart_rx_pin_(uart_rx_pin),
+      baud_rate_(baud_rate), timeout_ms_(LYDSTO_TIMEOUT_MS),
+      initialized_(false), timeout_occurred_(false), parser_len_(0),
+      total_rx_bytes_(0), header_fa_hits_(0), valid_packets_(0), failed_reads_(0) {}
 
 LYDSTO_Driver::~LYDSTO_Driver() {
     uart_driver_delete(uart_port_);
@@ -14,6 +27,8 @@ LYDSTO_Driver::~LYDSTO_Driver() {
 const char* LYDSTO_Driver::configure() { return nullptr; }
 
 const char* LYDSTO_Driver::init() {
+    ESP_LOGI(TAG, "UART init start (UART=%d RX=%d TX=%d BAUD=%lu)",
+             static_cast<int>(uart_port_), uart_rx_pin_, uart_tx_pin_, static_cast<unsigned long>(baud_rate_));
     uart_config_t cfg{};
     cfg.baud_rate = baud_rate_;
     cfg.data_bits = UART_DATA_8_BITS;
@@ -23,7 +38,9 @@ const char* LYDSTO_Driver::init() {
     if (uart_param_config(uart_port_, &cfg) != ESP_OK) return "uart_param_config failed";
     if (uart_set_pin(uart_port_, uart_tx_pin_, uart_rx_pin_, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE) != ESP_OK) return "uart_set_pin failed";
     if (uart_driver_install(uart_port_, 4096, 0, 0, nullptr, 0) != ESP_OK) return "uart_driver_install failed";
+    uart_flush_input(uart_port_);
     initialized_ = true;
+    ESP_LOGI(TAG, "UART init done");
     return nullptr;
 }
 
@@ -35,25 +52,18 @@ void LYDSTO_Driver::setTimeout(uint16_t timeout_ms) { timeout_ms_ = timeout_ms; 
 bool LYDSTO_Driver::timeoutOccurred() { return timeout_occurred_; }
 
 bool LYDSTO_Driver::validPacket(const uint8_t* p) const {
-    if (p[0] != COMMAND || p[1] < INDEX_LO || p[1] > 0xF9) return false;
-    uint32_t chk32 = 0;
-    for (int i = 0; i < 20; i += 2) {
-        uint16_t w = p[i] | (static_cast<uint16_t>(p[i + 1]) << 8);
-        chk32 = (chk32 << 1) + w;
-    }
-    uint16_t checksum = (chk32 & 0x7FFF) + (chk32 >> 15);
-    checksum &= 0x7FFF;
-    return (p[20] == (checksum & 0xFF)) && (p[21] == (checksum >> 8));
+    if (p[0] != COMMAND || p[1] != LENGTH_BYTE) return false;
+    uint16_t start_angle = p[4] | (static_cast<uint16_t>(p[5]) << 8);
+    uint16_t end_angle = p[42] | (static_cast<uint16_t>(p[43]) << 8);
+    if (start_angle > 36000 || end_angle > 36000) return false;
+    return true;
 }
 
 bool LYDSTO_Driver::extractMinDistance(const uint8_t* p, uint16_t& min_mm) const {
     min_mm = 0xFFFF;
-    for (int i = 0; i < 4; ++i) {
-        int off = 4 + i * 4;
-        uint8_t dataL = p[off];
-        uint8_t dataM = p[off + 1];
-        if (dataM & 0xC0) continue; // invalid or warning
-        uint16_t mm = dataL | ((dataM & 0x3F) << 8);
+    for (int i = 0; i < 12; ++i) {
+        int off = 6 + i * 3;
+        uint16_t mm = p[off] | (static_cast<uint16_t>(p[off + 1]) << 8);
         if (mm > 0 && mm < min_mm) min_mm = mm;
     }
     return min_mm != 0xFFFF;
@@ -62,12 +72,42 @@ bool LYDSTO_Driver::extractMinDistance(const uint8_t* p, uint16_t& min_mm) const
 bool LYDSTO_Driver::readPacket(uint8_t* packet) {
     timeout_occurred_ = false;
     int64_t deadline = esp_timer_get_time() + static_cast<int64_t>(timeout_ms_) * 1000;
-    uint8_t b;
+    uint8_t rx_tmp[128];
+    static int sample_log_budget = 8;
     while (esp_timer_get_time() < deadline) {
-        if (uart_read_bytes(uart_port_, &b, 1, pdMS_TO_TICKS(20)) == 1 && b == COMMAND) {
-            packet[0] = b;
-            int n = uart_read_bytes(uart_port_, packet + 1, PACKET_LEN - 1, pdMS_TO_TICKS(timeout_ms_));
-            if (n == PACKET_LEN - 1) return true;
+        int n = uart_read_bytes(uart_port_, rx_tmp, sizeof(rx_tmp), pdMS_TO_TICKS(20));
+        if (n > 0) {
+            total_rx_bytes_ += static_cast<uint32_t>(n);
+            for (int i = 0; i < n; ++i) {
+                if (rx_tmp[i] == COMMAND) header_fa_hits_++;
+            }
+            if (sample_log_budget > 0) {
+                log_hex_preview("RX chunk", rx_tmp, static_cast<size_t>(n));
+                sample_log_budget--;
+            }
+            size_t space = sizeof(parser_buf_) - parser_len_;
+            size_t copy_n = (static_cast<size_t>(n) < space) ? static_cast<size_t>(n) : space;
+            memcpy(parser_buf_ + parser_len_, rx_tmp, copy_n);
+            parser_len_ += copy_n;
+
+            for (size_t i = 0; i + PACKET_LEN <= parser_len_; ++i) {
+                if (parser_buf_[i] != COMMAND) continue;
+                if (validPacket(parser_buf_ + i)) {
+                    log_hex_preview("Valid packet", parser_buf_ + i, PACKET_LEN);
+                    memcpy(packet, parser_buf_ + i, PACKET_LEN);
+                    valid_packets_++;
+                    size_t remain = parser_len_ - (i + PACKET_LEN);
+                    memmove(parser_buf_, parser_buf_ + i + PACKET_LEN, remain);
+                    parser_len_ = remain;
+                    return true;
+                }
+            }
+
+            if (parser_len_ > PACKET_LEN) {
+                size_t keep = PACKET_LEN - 1;
+                memmove(parser_buf_, parser_buf_ + (parser_len_ - keep), keep);
+                parser_len_ = keep;
+            }
         }
     }
     timeout_occurred_ = true;
@@ -79,6 +119,27 @@ bool LYDSTO_Driver::read_sensor(MeasurementResult& result) {
     result.timestamp_us = esp_timer_get_time();
     uint8_t p[PACKET_LEN];
     if (!readPacket(p) || !validPacket(p)) {
+        failed_reads_++;
+        size_t buffered = 0;
+        uart_get_buffered_data_len(uart_port_, &buffered);
+        ESP_LOGW(TAG, "read_sensor failed (timeout=%d buffered=%u)",
+                 static_cast<int>(timeout_occurred_), static_cast<unsigned>(buffered));
+        if ((failed_reads_ % 20) == 0) {
+            ESP_LOGW(TAG,
+                     "RX stats: bytes=%lu fa_headers=%lu valid_packets=%lu failed_reads=%lu",
+                     static_cast<unsigned long>(total_rx_bytes_),
+                     static_cast<unsigned long>(header_fa_hits_),
+                     static_cast<unsigned long>(valid_packets_),
+                     static_cast<unsigned long>(failed_reads_));
+        }
+        if (parser_len_ > 0) {
+            log_hex_preview("Parser tail", parser_buf_, parser_len_);
+        }
+        if (buffered > 1024) {
+            ESP_LOGW(TAG, "input backlog detected, flushing UART RX buffer");
+            uart_flush_input(uart_port_);
+            parser_len_ = 0;
+        }
         result.valid = false;
         result.timeout_occurred = timeout_occurred_;
         result.range_status = 1;

--- a/components/sensor_control/include/lidar_sensor.hpp
+++ b/components/sensor_control/include/lidar_sensor.hpp
@@ -12,4 +12,8 @@ public:
 private:
   LYDSTO_Driver driver_;
   bool initialized_;
+  uart_port_t uart_port_;
+  int tx_pin_;
+  int rx_pin_;
+  uint32_t baud_rate_;
 };

--- a/components/sensor_control/include/sensor_control.h
+++ b/components/sensor_control/include/sensor_control.h
@@ -2,11 +2,11 @@
 
 // Centralized compile-time sensor presence
 #define SHELFBOT_HAS_ULTRASONIC 1
-#define SHELFBOT_HAS_TOF 1
+#define SHELFBOT_HAS_TOF 0
 #define SHELFBOT_HAS_LIDAR 1
 
 // Centralized ToF/LiDAR driver selection (choose exactly one)
 #define SHELFBOT_DRIVER_VL53L0X 0
 #define SHELFBOT_DRIVER_VL53L1 0
-#define SHELFBOT_DRIVER_VL53L1_MODBUS 0
-#define SHELFBOT_DRIVER_LYDSTO 1
+#define SHELFBOT_DRIVER_VL53L1_MODBUS 1
+#define SHELFBOT_DRIVER_LYDSTO 0

--- a/components/sensor_control/include/sensor_control.hpp
+++ b/components/sensor_control/include/sensor_control.hpp
@@ -117,6 +117,7 @@ private:
     // Internal helpers
     esp_err_t initialize_ultrasonic();
     esp_err_t initialize_tof();
+    esp_err_t initialize_lidar();
     esp_err_t update_lidar_measurement();
 
     static const char* TAG;

--- a/components/sensor_control/lidar_sensor.cpp
+++ b/components/sensor_control/lidar_sensor.cpp
@@ -1,15 +1,16 @@
 #include "lidar_sensor.hpp"
 LidarSensor::LidarSensor(const uart_port_t uart_port, int tx_pin, int rx_pin, uint32_t baud_rate)
-    : driver_(), initialized_(false) {
-  (void)uart_port;
-  (void)tx_pin;
-  (void)rx_pin;
-  (void)baud_rate;
-}
+    : driver_(uart_port, tx_pin, rx_pin, baud_rate), initialized_(false),
+      uart_port_(uart_port), tx_pin_(tx_pin), rx_pin_(rx_pin), baud_rate_(baud_rate) {}
 
 esp_err_t LidarSensor::initialize() {
+  ESP_LOGI("LidarSensor", "Initializing LYDSTO (UART=%d RX=%d TX=%d BAUD=%lu)",
+           static_cast<int>(uart_port_), rx_pin_, tx_pin_, static_cast<unsigned long>(baud_rate_));
   const char* err = driver_.init();
   initialized_ = (err == nullptr);
+  if (!initialized_) {
+    ESP_LOGE("LidarSensor", "LYDSTO init failed: %s", err ? err : "unknown error");
+  }
   return initialized_ ? ESP_OK : ESP_FAIL;
 }
 
@@ -24,5 +25,10 @@ esp_err_t LidarSensor::read(SensorCommon::LidarMeasurement& out) {
   out.timestamp_us = m.timestamp_us;
   out.timeout_occurred = m.timeout_occurred;
   out.health = out.valid ? 1 : 2;
+  if (!ok) {
+    ESP_LOGW("LidarSensor", "Read failed (timeout=%d status=%u valid=%d dist=%u)",
+             static_cast<int>(m.timeout_occurred), static_cast<unsigned>(m.range_status),
+             static_cast<int>(m.valid), static_cast<unsigned>(m.distance_mm));
+  }
   return ok ? ESP_OK : ESP_FAIL;
 }

--- a/components/sensor_control/sensor_control.cpp
+++ b/components/sensor_control/sensor_control.cpp
@@ -99,16 +99,30 @@ esp_err_t SensorControl::initialize_tof() {
     }
 
     ESP_LOGI(TAG, "TOF sensors initialized successfully");
+    return ESP_OK;
+}
+
+esp_err_t SensorControl::initialize_lidar() {
     if (config_.lidar_config.enabled) {
+#if SHELFBOT_DRIVER_LYDSTO
+        ESP_LOGW(TAG, "LiDAR is enabled, but SHELFBOT_DRIVER_LYDSTO already uses UART LYDSTO as the ToF driver.");
+        ESP_LOGW(TAG, "Skipping separate LidarSensor init to avoid double-installing UART driver on same peripheral.");
+        latest_data_.lidar_measurement.active = false;
+        latest_data_.lidar_measurement.valid = false;
+        latest_data_.lidar_measurement.health = 3; // conflict/misconfiguration
+#else
         lidar_sensor_ = std::make_unique<LidarSensor>(
             static_cast<uart_port_t>(config_.lidar_config.uart_port),
             config_.lidar_config.uart_tx_pin,
             config_.lidar_config.uart_rx_pin,
             config_.lidar_config.baud_rate);
         if (lidar_sensor_->initialize() != ESP_OK) {
-            ESP_LOGE(TAG, "Lidar UART init failed");
+            ESP_LOGW(TAG, "Lidar UART init failed; continuing without LiDAR");
             lidar_sensor_.reset();
-            return ESP_FAIL;
+            latest_data_.lidar_measurement.active = false;
+            latest_data_.lidar_measurement.valid = false;
+            latest_data_.lidar_measurement.health = 2;
+            return ESP_OK;
         }
         latest_data_.lidar_measurement.active = true;
         ESP_LOGI(TAG, "LidarSensor initialized (UART=%d RX=%d TX=%d BAUD=%lu)",
@@ -116,6 +130,7 @@ esp_err_t SensorControl::initialize_tof() {
                  config_.lidar_config.uart_rx_pin,
                  config_.lidar_config.uart_tx_pin,
                  static_cast<unsigned long>(config_.lidar_config.baud_rate));
+#endif
     } else {
         latest_data_.lidar_measurement.active = false;
     }
@@ -138,10 +153,19 @@ esp_err_t SensorControl::initialize() {
         return err;
     }
 
+#if SHELFBOT_HAS_TOF
     err = initialize_tof();
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "TOF initialization failed");
         ESP_LOGW(TAG, "Continuing without TOF sensors");
+    }
+#else
+    ESP_LOGW(TAG, "TOF category disabled at compile-time (SHELFBOT_HAS_TOF=0)");
+#endif
+
+    err = initialize_lidar();
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "LiDAR initialization had errors; continuing without LiDAR");
     }
 
     initialized_ = true;
@@ -275,11 +299,13 @@ void SensorControl::continuous_read_loop() {
 
             // Read ToF sensors
             SensorCommon::TofMeasurement tof_results[SensorCommon::NUM_TOF_SENSORS];
+#if SHELFBOT_HAS_TOF
             if (tof_sensor_ && tof_sensor_->read_all(tof_results) == ESP_OK) {
                 for (int i = 0; i < SensorCommon::NUM_TOF_SENSORS; i++) {
                     latest_data_.tof_measurements[i] = tof_results[i];
                 }
             }
+#endif
 
             latest_data_.timestamp_us = timestamp;
             update_lidar_measurement();

--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -352,13 +352,21 @@ void Shelfbot::begin() {
         {.trig_pin = 32, .echo_pin = 33, .timeout_us = 30000, .max_distance_mm = 4000}
     };
 
-    // Configure 3 ToF sensors
+    // Configure ToF sensors (disabled: no ToF devices connected)
     for (int i = 0; i < SensorCommon::NUM_TOF_SENSORS; i++) {
         sensor_config.tof_configs[i].timeout_ms = 500;
+        sensor_config.tof_configs[i].enabled = false;
     }
 
     sensor_config.ultrasonic_read_interval_ms = 100;
     sensor_config.tof_read_interval_ms = 200;
+
+    // Configure LYDSTO LiDAR over UART (RX on GPIO3)
+    sensor_config.lidar_config.enabled = true;
+    sensor_config.lidar_config.uart_port = UART_NUM_2;
+    sensor_config.lidar_config.uart_tx_pin = UART_PIN_NO_CHANGE;
+    sensor_config.lidar_config.uart_rx_pin = GPIO_NUM_3;
+    sensor_config.lidar_config.baud_rate = 115200;
 
     // Initialize the global sensor manager
     SensorManager::get_instance().initialize(sensor_config);


### PR DESCRIPTION
### Motivation
- Improve LYDSTO LDS02RR UART handling to support a different packet layout and noisy serial streams by adding a streaming parser and diagnostics. 
- Make the LYDSTO driver configurable at construction time for arbitrary UART port, pins and baud rate so it can be instantiated from higher-level sensor code. 
- Integrate LiDAR initialization/usage into the central SensorControl flow while avoiding UART driver conflicts when LYDSTO is used as the ToF driver. 

### Description
- Changed `LYDSTO_Driver` constructor to accept `uart_port`, `uart_tx_pin`, `uart_rx_pin`, and `baud_rate` and added internal fields for a streaming `parser_buf_`, statistics counters, and parsing state. 
- Updated packet constants (`PACKET_LEN`, `COMMAND`, `LENGTH_BYTE`) and replaced the single-read approach with a chunked reader in `readPacket` that accumulates bytes, searches for packet headers, validates packets using `validPacket`, and extracts minimum distance via `extractMinDistance` for the new payload layout. 
- Added logging helpers (`log_hex_preview`) and diagnostic logging for RX chunks, valid packets, parser tail, and RX statistics; added UART input flush during init and backlog handling when input grows large. 
- Updated `LidarSensor` to forward UART parameters to the driver, log initialization/read failures, and carry UART config state. 
- Extended `SensorControl` to add `initialize_lidar`, call it from the main `initialize` path, guard LiDAR initialization when `SHELFBOT_DRIVER_LYDSTO` is selected to avoid double-installing the UART driver, and conditionally include TOF reads when `SHELFBOT_HAS_TOF` is enabled. 
- Modified `sensor_control.h` defaults to disable the generic TOF category and switch the driver selection flags; updated `shelfbot.cpp` to configure the LYDSTO LiDAR UART parameters and disable ToF devices in the runtime config. 

### Testing
- Built the firmware using `idf.py build` which completed successfully on the CI/build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90da32e188322a25cebc624de5a76)