### PR TITLE
Add LiDAR live viewer, expose scan angles in JSON, and harden LYDSTO driver/packet parsing

### DIFF
--- a/components/http_server/CMakeLists.txt
+++ b/components/http_server/CMakeLists.txt
@@ -16,3 +16,13 @@ target_add_binary_data(
     "index.html"
     BINARY
 )
+target_add_binary_data(
+    ${COMPONENT_LIB}
+    "lidar.html"
+    BINARY
+)
+target_add_binary_data(
+    ${COMPONENT_LIB}
+    "lidar_viz.js"
+    BINARY
+)

--- a/components/http_server/http_server.cpp
+++ b/components/http_server/http_server.cpp
@@ -7,6 +7,10 @@
 #include "firmware_version.hpp"
 
 const char* HttpServer::TAG = "HttpServer";
+extern const uint8_t _binary_lidar_html_start[] asm("_binary_lidar_html_start");
+extern const uint8_t _binary_lidar_html_end[] asm("_binary_lidar_html_end");
+extern const uint8_t _binary_lidar_viz_js_start[] asm("_binary_lidar_viz_js_start");
+extern const uint8_t _binary_lidar_viz_js_end[] asm("_binary_lidar_viz_js_end");
 
 // Helper function to add CORS headers
 static void add_cors_headers(httpd_req_t* req) {
@@ -130,6 +134,22 @@ esp_err_t HttpServer::register_uri_handlers() {
     };
     httpd_register_uri_handler(server_, &motor_page_uri);
 
+    httpd_uri_t lidar_page_uri = {
+        .uri = "/lidar.html",
+        .method = HTTP_GET,
+        .handler = lidar_page_handler,
+        .user_ctx = nullptr
+    };
+    httpd_register_uri_handler(server_, &lidar_page_uri);
+
+    httpd_uri_t lidar_js_uri = {
+        .uri = "/lidar_viz.js",
+        .method = HTTP_GET,
+        .handler = lidar_js_handler,
+        .user_ctx = nullptr
+    };
+    httpd_register_uri_handler(server_, &lidar_js_uri);
+
     httpd_uri_t motor_status_uri = {
         .uri = "/api/motor/status",
         .method = HTTP_GET,
@@ -201,6 +221,18 @@ load(); setInterval(load,500);
 </script></body></html>)HTML";
     httpd_resp_set_type(req, "text/html; charset=utf-8");
     return httpd_resp_send(req, page.c_str(), HTTPD_RESP_USE_STRLEN);
+}
+
+esp_err_t HttpServer::lidar_page_handler(httpd_req_t* req) {
+    httpd_resp_set_type(req, "text/html; charset=utf-8");
+    const size_t len = _binary_lidar_html_end - _binary_lidar_html_start;
+    return httpd_resp_send(req, reinterpret_cast<const char*>(_binary_lidar_html_start), len);
+}
+
+esp_err_t HttpServer::lidar_js_handler(httpd_req_t* req) {
+    httpd_resp_set_type(req, "application/javascript; charset=utf-8");
+    const size_t len = _binary_lidar_viz_js_end - _binary_lidar_viz_js_start;
+    return httpd_resp_send(req, reinterpret_cast<const char*>(_binary_lidar_viz_js_start), len);
 }
 
 esp_err_t HttpServer::motor_status_handler(httpd_req_t* req) {
@@ -279,6 +311,7 @@ esp_err_t HttpServer::root_handler(httpd_req_t* req) {
                     <div class="card"><h3>📦 Sensor Dashboard</h3><p><a href="/api/sensors">Open all sensors JSON</a></p><code>GET /api/sensors</code></div>
                     <div class="card"><h3>📡 ToF</h3><p><a href="/api/tof">Open ToF JSON</a></p><code>GET /api/tof</code></div>
                     <div class="card"><h3>🛰️ LiDAR</h3><p><a href="/api/lidar">Open LiDAR JSON</a></p><code>GET /api/lidar</code></div>
+                    <div class="card"><h3>🗺️ LiDAR Viewer</h3><p><a href="/lidar.html">Open live LiDAR visualization</a></p><code>/lidar.html</code></div>
                     <div class="card"><h3>📏 Ultrasonic</h3><p><a href="/api/ultrasonic">Open ultrasonic JSON</a></p><code>GET /api/ultrasonic</code></div>
                     <div class="card"><h3>⚙️ Motor Control UI</h3><p><a href="/motor.html">Open motor control page</a></p><code>/motor.html</code></div>
                     <div class="card"><h3>❤️ Health</h3><p><a href="/api/health">Open system health JSON</a></p><code>GET /api/health</code></div>
@@ -420,6 +453,9 @@ cJSON* HttpServer::create_sensor_json(const SensorCommon::SensorDataPacket& sens
     cJSON_AddNumberToObject(lidar_json, "distance_mm", lidar.distance_mm);
     cJSON_AddNumberToObject(lidar_json, "distance_cm", lidar.distance_cm());
     cJSON_AddNumberToObject(lidar_json, "status", lidar.status);
+    cJSON_AddNumberToObject(lidar_json, "start_angle_deg", lidar.start_angle_deg);
+    cJSON_AddNumberToObject(lidar_json, "end_angle_deg", lidar.end_angle_deg);
+    cJSON_AddNumberToObject(lidar_json, "min_distance_angle_deg", lidar.min_distance_angle_deg);
     cJSON_AddStringToObject(lidar_json, "status_text", get_sensor_status_text(lidar).c_str());
     cJSON_AddNumberToObject(lidar_json, "timestamp_us", lidar.timestamp_us);
     cJSON_AddBoolToObject(lidar_json, "timeout_occurred", lidar.timeout_occurred);
@@ -491,6 +527,9 @@ esp_err_t HttpServer::lidar_handler(httpd_req_t* req) {
     cJSON_AddNumberToObject(root, "distance_mm", m.distance_mm);
     cJSON_AddNumberToObject(root, "distance_cm", m.distance_cm());
     cJSON_AddNumberToObject(root, "status", m.status);
+    cJSON_AddNumberToObject(root, "start_angle_deg", m.start_angle_deg);
+    cJSON_AddNumberToObject(root, "end_angle_deg", m.end_angle_deg);
+    cJSON_AddNumberToObject(root, "min_distance_angle_deg", m.min_distance_angle_deg);
     cJSON_AddStringToObject(root, "status_text", get_sensor_status_text(m).c_str());
     cJSON_AddNumberToObject(root, "timestamp_us", m.timestamp_us);
     cJSON_AddBoolToObject(root, "timeout_occurred", m.timeout_occurred);

--- a/components/http_server/include/http_server.hpp
+++ b/components/http_server/include/http_server.hpp
@@ -44,6 +44,8 @@ private:
   static esp_err_t sensors_handler(httpd_req_t* req);
   static esp_err_t health_handler(httpd_req_t* req);
   static esp_err_t motor_page_handler(httpd_req_t* req);
+  static esp_err_t lidar_page_handler(httpd_req_t* req);
+  static esp_err_t lidar_js_handler(httpd_req_t* req);
   static esp_err_t motor_status_handler(httpd_req_t* req);
   static esp_err_t motor_set_handler(httpd_req_t* req);
 

--- a/components/http_server/lidar.html
+++ b/components/http_server/lidar.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Shelfbot LiDAR Viewer</title>
+  <style>
+    body{font-family:Inter,Arial,sans-serif;margin:0;background:#0f172a;color:#e2e8f0}
+    .wrap{max-width:1100px;margin:0 auto;padding:24px}
+    .top{display:flex;justify-content:space-between;align-items:center}
+    .card{background:#1e293b;border:1px solid #334155;border-radius:12px;padding:16px;margin-top:16px}
+    a{color:#93c5fd;text-decoration:none;font-weight:600}
+    a:hover{text-decoration:underline}
+    #meta{font-family:monospace;white-space:pre-wrap;color:#a7f3d0}
+    svg{width:100%;max-width:700px;height:auto;background:#020617;border-radius:12px;border:1px solid #334155}
+    .legend{font-size:13px;color:#94a3b8;margin-top:8px}
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <div class="top"><h1>🛰️ LiDAR Live Viewer</h1><a href="/">← Main Dashboard</a></div>
+  <div class="card">
+    <svg id="lidar" viewBox="0 0 600 600" role="img" aria-label="Live LiDAR scan"></svg>
+    <div class="legend">Click any point to inspect angle and distance.</div>
+  </div>
+  <div class="card"><h3>Scan Metadata</h3><div id="meta">Loading...</div></div>
+</div>
+<script src="/lidar_viz.js"></script>
+</body>
+</html>

--- a/components/http_server/lidar_viz.js
+++ b/components/http_server/lidar_viz.js
@@ -1,0 +1,81 @@
+(function(){
+  const svg = document.getElementById('lidar');
+  const meta = document.getElementById('meta');
+  const size = 600;
+  const cx = size/2;
+  const cy = size/2;
+  const scale = 0.12; // mm to px
+
+  function el(name, attrs) {
+    const node = document.createElementNS('http://www.w3.org/2000/svg', name);
+    Object.keys(attrs).forEach(k => node.setAttribute(k, attrs[k]));
+    return node;
+  }
+
+  function drawGrid() {
+    svg.innerHTML = '';
+    [500, 1000, 1500, 2000].forEach(mm => {
+      svg.appendChild(el('circle', {cx, cy, r: mm*scale, fill:'none', stroke:'#1e293b', 'stroke-width':'1'}));
+    });
+    svg.appendChild(el('line', {x1:0,y1:cy,x2:size,y2:cy,stroke:'#1e293b'}));
+    svg.appendChild(el('line', {x1:cx,y1:0,x2:cx,y2:size,stroke:'#1e293b'}));
+    svg.appendChild(el('circle', {cx, cy, r:4, fill:'#22d3ee'}));
+  }
+
+  function pointToXY(distanceMm, angleDeg) {
+    const rad = (angleDeg - 90) * Math.PI / 180;
+    return {
+      x: cx + Math.cos(rad) * distanceMm * scale,
+      y: cy + Math.sin(rad) * distanceMm * scale
+    };
+  }
+
+  function drawScan(data) {
+    drawGrid();
+    const points = (data.points || []).filter(p => p && p.valid && p.distance_mm > 0);
+    points.forEach((p) => {
+      const pt = pointToXY(p.distance_mm, p.angle_deg);
+      const dot = el('circle', {cx:pt.x, cy:pt.y, r:2.5, fill:'#4ade80', cursor:'pointer'});
+      dot.addEventListener('click', () => {
+        meta.textContent = JSON.stringify({
+          clicked_point: {
+            angle_deg: p.angle_deg,
+            distance_mm: p.distance_mm,
+            intensity: p.intensity
+          },
+          start_angle_deg: data.start_angle_deg,
+          end_angle_deg: data.end_angle_deg,
+          min_distance_angle_deg: data.min_distance_angle_deg,
+          point_count: points.length,
+          timestamp_ms: data.timestamp_ms
+        }, null, 2);
+      });
+      svg.appendChild(dot);
+    });
+
+    if (points.length === 0) {
+      meta.textContent = 'No valid points in current frame.';
+    } else {
+      meta.textContent = JSON.stringify({
+        start_angle_deg: data.start_angle_deg,
+        end_angle_deg: data.end_angle_deg,
+        min_distance_angle_deg: data.min_distance_angle_deg,
+        point_count: points.length,
+        timestamp_ms: data.timestamp_ms
+      }, null, 2);
+    }
+  }
+
+  async function refresh() {
+    try {
+      const res = await fetch('/api/lidar');
+      const data = await res.json();
+      drawScan(data);
+    } catch (e) {
+      meta.textContent = 'Failed to fetch /api/lidar: ' + e;
+    }
+  }
+
+  refresh();
+  setInterval(refresh, 400);
+})();

--- a/components/lydsto_driver/include/lydsto.hpp
+++ b/components/lydsto_driver/include/lydsto.hpp
@@ -16,9 +16,15 @@ public:
         bool     valid;
         bool     timeout_occurred;
         int64_t  timestamp_us;
+        float    start_angle_deg;
+        float    end_angle_deg;
+        float    min_distance_angle_deg;
     };
 
-    LYDSTO_Driver();
+    LYDSTO_Driver(uart_port_t uart_port = LYDSTO_UART_PORT,
+                  int uart_tx_pin = LYDSTO_TX_PIN,
+                  int uart_rx_pin = LYDSTO_RX_PIN,
+                  uint32_t baud_rate = LYDSTO_BAUD_RATE);
     ~LYDSTO_Driver();
 
     const char* configure();
@@ -31,14 +37,16 @@ public:
 
     void setTimeout(uint16_t timeout_ms);
     bool timeoutOccurred();
+    bool get_last_packet(uint8_t* out, size_t len) const;
+    uint32_t get_packet_count() const { return valid_packets_; }
 
     LYDSTO_Driver(const LYDSTO_Driver&) = delete;
     LYDSTO_Driver& operator=(const LYDSTO_Driver&) = delete;
 
 private:
-    static constexpr uint8_t PACKET_LEN = 22;
-    static constexpr uint8_t COMMAND = 0xFA;
-    static constexpr uint8_t INDEX_LO = 0xA0;
+    static constexpr uint8_t PACKET_LEN = 47;
+    static constexpr uint8_t COMMAND = 0x54;
+    static constexpr uint8_t LENGTH_BYTE = 0x2C;
 
     uart_port_t uart_port_;
     int uart_tx_pin_;
@@ -48,10 +56,16 @@ private:
 
     bool initialized_;
     bool timeout_occurred_;
+    uint8_t parser_buf_[512];
+    size_t parser_len_;
+    uint32_t total_rx_bytes_;
+    uint32_t header_fa_hits_;
+    uint32_t valid_packets_;
+    uint32_t failed_reads_;
+    uint8_t last_packet_[47];
+    bool has_last_packet_;
 
     bool readPacket(uint8_t* packet);
     bool validPacket(const uint8_t* packet) const;
-    bool extractMinDistance(const uint8_t* packet, uint16_t& min_mm) const;
+    bool extractMinDistance(const uint8_t* packet, uint16_t& min_mm, int& min_idx) const;
 };
-
-using TofDriver = LYDSTO_Driver;

--- a/components/lydsto_driver/lydsto.cpp
+++ b/components/lydsto_driver/lydsto.cpp
@@ -1,11 +1,35 @@
 #include "lydsto.hpp"
 
-static const char* TAG = "TofDriver_LYDSTO";
+static const char* TAG = "LidarDriver_LYDSTO";
 
-LYDSTO_Driver::LYDSTO_Driver()
-    : uart_port_(LYDSTO_UART_PORT), uart_tx_pin_(LYDSTO_TX_PIN), uart_rx_pin_(LYDSTO_RX_PIN),
-      baud_rate_(LYDSTO_BAUD_RATE), timeout_ms_(LYDSTO_TIMEOUT_MS),
-      initialized_(false), timeout_occurred_(false) {}
+static void log_hex_preview(const char* prefix, const uint8_t* data, size_t len) {
+    char line[3 * 24 + 1] = {0};
+    size_t n = (len < 24) ? len : 24;
+    size_t off = 0;
+    for (size_t i = 0; i < n && off + 4 < sizeof(line); ++i) {
+        int wrote = snprintf(line + off, sizeof(line) - off, "%02X ", data[i]);
+        if (wrote <= 0) break;
+        off += static_cast<size_t>(wrote);
+    }
+    ESP_LOGW(TAG, "%s (%uB): %s", prefix, static_cast<unsigned>(len), line);
+}
+
+static uint8_t crc8_poly4d(const uint8_t* data, size_t len) {
+    uint8_t crc = 0x00;
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; ++b) {
+            crc = (crc & 0x80) ? static_cast<uint8_t>((crc << 1) ^ 0x4D) : static_cast<uint8_t>(crc << 1);
+        }
+    }
+    return crc;
+}
+
+LYDSTO_Driver::LYDSTO_Driver(uart_port_t uart_port, int uart_tx_pin, int uart_rx_pin, uint32_t baud_rate)
+    : uart_port_(uart_port), uart_tx_pin_(uart_tx_pin), uart_rx_pin_(uart_rx_pin),
+      baud_rate_(baud_rate), timeout_ms_(LYDSTO_TIMEOUT_MS),
+      initialized_(false), timeout_occurred_(false), parser_len_(0),
+      total_rx_bytes_(0), header_fa_hits_(0), valid_packets_(0), failed_reads_(0), has_last_packet_(false) {}
 
 LYDSTO_Driver::~LYDSTO_Driver() {
     uart_driver_delete(uart_port_);
@@ -14,6 +38,8 @@ LYDSTO_Driver::~LYDSTO_Driver() {
 const char* LYDSTO_Driver::configure() { return nullptr; }
 
 const char* LYDSTO_Driver::init() {
+    ESP_LOGI(TAG, "UART init start (UART=%d RX=%d TX=%d BAUD=%lu)",
+             static_cast<int>(uart_port_), uart_rx_pin_, uart_tx_pin_, static_cast<unsigned long>(baud_rate_));
     uart_config_t cfg{};
     cfg.baud_rate = baud_rate_;
     cfg.data_bits = UART_DATA_8_BITS;
@@ -23,7 +49,9 @@ const char* LYDSTO_Driver::init() {
     if (uart_param_config(uart_port_, &cfg) != ESP_OK) return "uart_param_config failed";
     if (uart_set_pin(uart_port_, uart_tx_pin_, uart_rx_pin_, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE) != ESP_OK) return "uart_set_pin failed";
     if (uart_driver_install(uart_port_, 4096, 0, 0, nullptr, 0) != ESP_OK) return "uart_driver_install failed";
+    uart_flush_input(uart_port_);
     initialized_ = true;
+    ESP_LOGI(TAG, "UART init done");
     return nullptr;
 }
 
@@ -33,41 +61,80 @@ const char* LYDSTO_Driver::check() { return initialized_ ? nullptr : "Not initia
 bool LYDSTO_Driver::isReady() const { return initialized_; }
 void LYDSTO_Driver::setTimeout(uint16_t timeout_ms) { timeout_ms_ = timeout_ms; }
 bool LYDSTO_Driver::timeoutOccurred() { return timeout_occurred_; }
-
-bool LYDSTO_Driver::validPacket(const uint8_t* p) const {
-    if (p[0] != COMMAND || p[1] < INDEX_LO || p[1] > 0xF9) return false;
-    uint32_t chk32 = 0;
-    for (int i = 0; i < 20; i += 2) {
-        uint16_t w = p[i] | (static_cast<uint16_t>(p[i + 1]) << 8);
-        chk32 = (chk32 << 1) + w;
-    }
-    uint16_t checksum = (chk32 & 0x7FFF) + (chk32 >> 15);
-    checksum &= 0x7FFF;
-    return (p[20] == (checksum & 0xFF)) && (p[21] == (checksum >> 8));
+bool LYDSTO_Driver::get_last_packet(uint8_t* out, size_t len) const {
+    if (!has_last_packet_ || !out || len < PACKET_LEN) return false;
+    memcpy(out, last_packet_, PACKET_LEN);
+    return true;
 }
 
-bool LYDSTO_Driver::extractMinDistance(const uint8_t* p, uint16_t& min_mm) const {
-    min_mm = 0xFFFF;
-    for (int i = 0; i < 4; ++i) {
-        int off = 4 + i * 4;
-        uint8_t dataL = p[off];
-        uint8_t dataM = p[off + 1];
-        if (dataM & 0xC0) continue; // invalid or warning
-        uint16_t mm = dataL | ((dataM & 0x3F) << 8);
-        if (mm > 0 && mm < min_mm) min_mm = mm;
+bool LYDSTO_Driver::validPacket(const uint8_t* p) const {
+    if (p[0] != COMMAND || p[1] != LENGTH_BYTE) return false;
+    uint16_t start_angle = p[4] | (static_cast<uint16_t>(p[5]) << 8);
+    uint16_t end_angle = p[42] | (static_cast<uint16_t>(p[43]) << 8);
+    if (start_angle > 36000 || end_angle > 36000) return false;
+    uint8_t expected_crc = crc8_poly4d(p, PACKET_LEN - 1);
+    uint8_t frame_crc = p[PACKET_LEN - 1];
+    if (expected_crc != frame_crc) {
+        return false;
     }
-    return min_mm != 0xFFFF;
+    return true;
+}
+
+bool LYDSTO_Driver::extractMinDistance(const uint8_t* p, uint16_t& min_mm, int& min_idx) const {
+    min_mm = 0xFFFF;
+    min_idx = -1;
+    for (int i = 0; i < 12; ++i) {
+        int off = 6 + i * 3;
+        uint16_t mm = p[off] | (static_cast<uint16_t>(p[off + 1]) << 8);
+        if (mm > 0 && mm < min_mm) {
+            min_mm = mm;
+            min_idx = i;
+        }
+    }
+    return min_idx >= 0;
 }
 
 bool LYDSTO_Driver::readPacket(uint8_t* packet) {
     timeout_occurred_ = false;
     int64_t deadline = esp_timer_get_time() + static_cast<int64_t>(timeout_ms_) * 1000;
-    uint8_t b;
+    uint8_t rx_tmp[128];
+    static int sample_log_budget = 8;
     while (esp_timer_get_time() < deadline) {
-        if (uart_read_bytes(uart_port_, &b, 1, pdMS_TO_TICKS(20)) == 1 && b == COMMAND) {
-            packet[0] = b;
-            int n = uart_read_bytes(uart_port_, packet + 1, PACKET_LEN - 1, pdMS_TO_TICKS(timeout_ms_));
-            if (n == PACKET_LEN - 1) return true;
+        int n = uart_read_bytes(uart_port_, rx_tmp, sizeof(rx_tmp), pdMS_TO_TICKS(20));
+        if (n > 0) {
+            total_rx_bytes_ += static_cast<uint32_t>(n);
+            for (int i = 0; i < n; ++i) {
+                if (rx_tmp[i] == COMMAND) header_fa_hits_++;
+            }
+            if (sample_log_budget > 0) {
+                log_hex_preview("RX chunk", rx_tmp, static_cast<size_t>(n));
+                sample_log_budget--;
+            }
+            size_t space = sizeof(parser_buf_) - parser_len_;
+            size_t copy_n = (static_cast<size_t>(n) < space) ? static_cast<size_t>(n) : space;
+            memcpy(parser_buf_ + parser_len_, rx_tmp, copy_n);
+            parser_len_ += copy_n;
+
+            for (size_t i = 0; i + PACKET_LEN <= parser_len_; ++i) {
+                if (parser_buf_[i] != COMMAND) continue;
+                if (validPacket(parser_buf_ + i)) {
+                    log_hex_preview("Valid packet", parser_buf_ + i, PACKET_LEN);
+                    memcpy(packet, parser_buf_ + i, PACKET_LEN);
+                    memcpy(last_packet_, packet, PACKET_LEN);
+                    has_last_packet_ = true;
+                    valid_packets_++;
+                    size_t remain = parser_len_ - (i + PACKET_LEN);
+                    memmove(parser_buf_, parser_buf_ + i + PACKET_LEN, remain);
+                    parser_len_ = remain;
+                    return true;
+                }
+            }
+
+            if (parser_len_ > PACKET_LEN) {
+                size_t keep = PACKET_LEN - 1;
+                memmove(parser_buf_, parser_buf_ + (parser_len_ - keep), keep);
+                parser_len_ = keep;
+            }
         }
     }
     timeout_occurred_ = true;
@@ -79,19 +146,55 @@ bool LYDSTO_Driver::read_sensor(MeasurementResult& result) {
     result.timestamp_us = esp_timer_get_time();
     uint8_t p[PACKET_LEN];
     if (!readPacket(p) || !validPacket(p)) {
+        failed_reads_++;
+        size_t buffered = 0;
+        uart_get_buffered_data_len(uart_port_, &buffered);
+        ESP_LOGW(TAG, "read_sensor failed (timeout=%d buffered=%u)",
+                 static_cast<int>(timeout_occurred_), static_cast<unsigned>(buffered));
+        if ((failed_reads_ % 20) == 0) {
+            ESP_LOGW(TAG,
+                     "RX stats: bytes=%lu fa_headers=%lu valid_packets=%lu failed_reads=%lu",
+                     static_cast<unsigned long>(total_rx_bytes_),
+                     static_cast<unsigned long>(header_fa_hits_),
+                     static_cast<unsigned long>(valid_packets_),
+                     static_cast<unsigned long>(failed_reads_));
+            if (total_rx_bytes_ > 5000 && valid_packets_ == 0) {
+                ESP_LOGW(TAG, "No valid frames despite traffic. Check UART mismatch: baud/parity/stop bits/voltage levels.");
+            }
+        }
+        if (parser_len_ > 0) {
+            log_hex_preview("Parser tail", parser_buf_, parser_len_);
+        }
+        if (buffered > 1024) {
+            ESP_LOGW(TAG, "input backlog detected, flushing UART RX buffer");
+            uart_flush_input(uart_port_);
+            parser_len_ = 0;
+        }
         result.valid = false;
         result.timeout_occurred = timeout_occurred_;
         result.range_status = 1;
         return false;
     }
     uint16_t mm;
-    if (!extractMinDistance(p, mm)) {
+    int min_idx = -1;
+    uint16_t sa = p[4] | (static_cast<uint16_t>(p[5]) << 8);
+    uint16_t ea = p[42] | (static_cast<uint16_t>(p[43]) << 8);
+    float start_deg = sa / 100.0f;
+    float end_deg = ea / 100.0f;
+    float span = end_deg - start_deg;
+    if (span < 0.0f) span += 360.0f;
+    result.start_angle_deg = start_deg;
+    result.end_angle_deg = end_deg;
+    if (!extractMinDistance(p, mm, min_idx)) {
         result.valid = false;
         result.range_status = 2;
         result.timeout_occurred = false;
-        return false;
+        result.min_distance_angle_deg = start_deg;
+        return true;
     }
     result.distance_mm = mm;
+    result.min_distance_angle_deg = start_deg + (span * static_cast<float>(min_idx) / 11.0f);
+    if (result.min_distance_angle_deg >= 360.0f) result.min_distance_angle_deg -= 360.0f;
     result.valid = true;
     result.range_status = 0;
     result.timeout_occurred = false;

--- a/components/sensor_control/CMakeLists.txt
+++ b/components/sensor_control/CMakeLists.txt
@@ -3,6 +3,7 @@ idf_component_register(
   "ultrasonic_sensor.cpp"
   "tof_sensor.cpp"
   "lidar_sensor.cpp"
+  "lidar_packet_parser.cpp"
   "sensor_control.cpp"
   "sensor_manager.cpp"
   "i2c_scanner.cpp"

--- a/components/sensor_control/include/lidar_packet_parser.hpp
+++ b/components/sensor_control/include/lidar_packet_parser.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <idf_c_includes.hpp>
+#include <array>
+#include <string>
+
+struct LidarParsedPacket {
+    bool valid;
+    uint16_t speed;
+    float start_angle_deg;
+    float end_angle_deg;
+    std::array<uint16_t, 12> distances_mm;
+    std::array<uint8_t, 12> confidences;
+    uint16_t timestamp;
+    uint8_t crc;
+    std::string json;
+};
+
+class LidarPacketParser {
+public:
+    static bool parse(const uint8_t* packet, size_t len, LidarParsedPacket& out);
+};

--- a/components/sensor_control/include/lidar_sensor.hpp
+++ b/components/sensor_control/include/lidar_sensor.hpp
@@ -9,7 +9,13 @@ public:
   bool is_ready() const { return initialized_ && driver_.isReady(); }
   esp_err_t initialize();
   esp_err_t read(SensorCommon::LidarMeasurement& out);
+  bool get_last_raw_packet(uint8_t* out, size_t len) const { return driver_.get_last_packet(out, len); }
+  uint32_t packet_count() const { return driver_.get_packet_count(); }
 private:
   LYDSTO_Driver driver_;
   bool initialized_;
+  uart_port_t uart_port_;
+  int tx_pin_;
+  int rx_pin_;
+  uint32_t baud_rate_;
 };

--- a/components/sensor_control/include/sensor_common.hpp
+++ b/components/sensor_control/include/sensor_common.hpp
@@ -45,9 +45,13 @@ namespace SensorCommon {
     int64_t timestamp_us;
     bool timeout_occurred;
     uint8_t health;       // 0=unknown, 1=ok, >1 degraded/error
+    float start_angle_deg;
+    float end_angle_deg;
+    float min_distance_angle_deg;
 
     LidarMeasurement() : distance_mm(0), active(false), valid(false), status(0),
-                         timestamp_us(0), timeout_occurred(false), health(0) {}
+                         timestamp_us(0), timeout_occurred(false), health(0),
+                         start_angle_deg(0.0f), end_angle_deg(0.0f), min_distance_angle_deg(0.0f) {}
 
     float distance_cm() const { return distance_mm / 10.0f; }
   };

--- a/components/sensor_control/include/sensor_control.h
+++ b/components/sensor_control/include/sensor_control.h
@@ -2,11 +2,11 @@
 
 // Centralized compile-time sensor presence
 #define SHELFBOT_HAS_ULTRASONIC 1
-#define SHELFBOT_HAS_TOF 1
+#define SHELFBOT_HAS_TOF 0
 #define SHELFBOT_HAS_LIDAR 1
 
 // Centralized ToF/LiDAR driver selection (choose exactly one)
 #define SHELFBOT_DRIVER_VL53L0X 0
 #define SHELFBOT_DRIVER_VL53L1 0
-#define SHELFBOT_DRIVER_VL53L1_MODBUS 0
-#define SHELFBOT_DRIVER_LYDSTO 1
+#define SHELFBOT_DRIVER_VL53L1_MODBUS 1
+#define SHELFBOT_DRIVER_LYDSTO 0

--- a/components/sensor_control/include/sensor_control.hpp
+++ b/components/sensor_control/include/sensor_control.hpp
@@ -117,6 +117,7 @@ private:
     // Internal helpers
     esp_err_t initialize_ultrasonic();
     esp_err_t initialize_tof();
+    esp_err_t initialize_lidar();
     esp_err_t update_lidar_measurement();
 
     static const char* TAG;

--- a/components/sensor_control/lidar_packet_parser.cpp
+++ b/components/sensor_control/lidar_packet_parser.cpp
@@ -1,0 +1,34 @@
+#include "include/lidar_packet_parser.hpp"
+#include <sstream>
+
+bool LidarPacketParser::parse(const uint8_t* p, size_t len, LidarParsedPacket& out) {
+    if (!p || len < 47 || p[0] != 0x54 || p[1] != 0x2C) return false;
+    out.valid = true;
+    out.speed = p[2] | (static_cast<uint16_t>(p[3]) << 8);
+    uint16_t sa = p[4] | (static_cast<uint16_t>(p[5]) << 8);
+    uint16_t ea = p[42] | (static_cast<uint16_t>(p[43]) << 8);
+    out.start_angle_deg = sa / 100.0f;
+    out.end_angle_deg = ea / 100.0f;
+    for (int i = 0; i < 12; ++i) {
+        int off = 6 + i * 3;
+        out.distances_mm[i] = p[off] | (static_cast<uint16_t>(p[off + 1]) << 8);
+        out.confidences[i] = p[off + 2];
+    }
+    out.timestamp = p[44] | (static_cast<uint16_t>(p[45]) << 8);
+    out.crc = p[46];
+
+    std::ostringstream ss;
+    ss << "{\"speed\":" << out.speed
+       << ",\"start_angle_deg\":" << out.start_angle_deg
+       << ",\"end_angle_deg\":" << out.end_angle_deg
+       << ",\"timestamp\":" << out.timestamp
+       << ",\"crc\":" << static_cast<unsigned>(out.crc)
+       << ",\"points\":[";
+    for (int i = 0; i < 12; ++i) {
+        if (i) ss << ",";
+        ss << "{\"d\":" << out.distances_mm[i] << ",\"c\":" << static_cast<unsigned>(out.confidences[i]) << "}";
+    }
+    ss << "]}";
+    out.json = ss.str();
+    return true;
+}

--- a/components/sensor_control/lidar_sensor.cpp
+++ b/components/sensor_control/lidar_sensor.cpp
@@ -1,15 +1,16 @@
 #include "lidar_sensor.hpp"
 LidarSensor::LidarSensor(const uart_port_t uart_port, int tx_pin, int rx_pin, uint32_t baud_rate)
-    : driver_(), initialized_(false) {
-  (void)uart_port;
-  (void)tx_pin;
-  (void)rx_pin;
-  (void)baud_rate;
-}
+    : driver_(uart_port, tx_pin, rx_pin, baud_rate), initialized_(false),
+      uart_port_(uart_port), tx_pin_(tx_pin), rx_pin_(rx_pin), baud_rate_(baud_rate) {}
 
 esp_err_t LidarSensor::initialize() {
+  ESP_LOGI("LidarSensor", "Initializing LYDSTO (UART=%d RX=%d TX=%d BAUD=%lu)",
+           static_cast<int>(uart_port_), rx_pin_, tx_pin_, static_cast<unsigned long>(baud_rate_));
   const char* err = driver_.init();
   initialized_ = (err == nullptr);
+  if (!initialized_) {
+    ESP_LOGE("LidarSensor", "LYDSTO init failed: %s", err ? err : "unknown error");
+  }
   return initialized_ ? ESP_OK : ESP_FAIL;
 }
 
@@ -23,6 +24,14 @@ esp_err_t LidarSensor::read(SensorCommon::LidarMeasurement& out) {
   out.status = m.range_status;
   out.timestamp_us = m.timestamp_us;
   out.timeout_occurred = m.timeout_occurred;
+  out.start_angle_deg = m.start_angle_deg;
+  out.end_angle_deg = m.end_angle_deg;
+  out.min_distance_angle_deg = m.min_distance_angle_deg;
   out.health = out.valid ? 1 : 2;
+  if (!ok) {
+    ESP_LOGW("LidarSensor", "Read failed (timeout=%d status=%u valid=%d dist=%u)",
+             static_cast<int>(m.timeout_occurred), static_cast<unsigned>(m.range_status),
+             static_cast<int>(m.valid), static_cast<unsigned>(m.distance_mm));
+  }
   return ok ? ESP_OK : ESP_FAIL;
 }

--- a/components/sensor_control/sensor_control.cpp
+++ b/components/sensor_control/sensor_control.cpp
@@ -4,6 +4,7 @@
 #include "tof_sensor.hpp"
 #include "lidar_sensor.hpp"
 #include "sensor_common.hpp"
+#include "lidar_packet_parser.hpp"
 #include "firmware_version.hpp"
 
 const char* SensorControl::TAG = "SensorControl";
@@ -99,16 +100,30 @@ esp_err_t SensorControl::initialize_tof() {
     }
 
     ESP_LOGI(TAG, "TOF sensors initialized successfully");
+    return ESP_OK;
+}
+
+esp_err_t SensorControl::initialize_lidar() {
     if (config_.lidar_config.enabled) {
+#if SHELFBOT_DRIVER_LYDSTO
+        ESP_LOGW(TAG, "LiDAR is enabled, but SHELFBOT_DRIVER_LYDSTO already uses UART LYDSTO as the ToF driver.");
+        ESP_LOGW(TAG, "Skipping separate LidarSensor init to avoid double-installing UART driver on same peripheral.");
+        latest_data_.lidar_measurement.active = false;
+        latest_data_.lidar_measurement.valid = false;
+        latest_data_.lidar_measurement.health = 3; // conflict/misconfiguration
+#else
         lidar_sensor_ = std::make_unique<LidarSensor>(
             static_cast<uart_port_t>(config_.lidar_config.uart_port),
             config_.lidar_config.uart_tx_pin,
             config_.lidar_config.uart_rx_pin,
             config_.lidar_config.baud_rate);
         if (lidar_sensor_->initialize() != ESP_OK) {
-            ESP_LOGE(TAG, "Lidar UART init failed");
+            ESP_LOGW(TAG, "Lidar UART init failed; continuing without LiDAR");
             lidar_sensor_.reset();
-            return ESP_FAIL;
+            latest_data_.lidar_measurement.active = false;
+            latest_data_.lidar_measurement.valid = false;
+            latest_data_.lidar_measurement.health = 2;
+            return ESP_OK;
         }
         latest_data_.lidar_measurement.active = true;
         ESP_LOGI(TAG, "LidarSensor initialized (UART=%d RX=%d TX=%d BAUD=%lu)",
@@ -116,6 +131,7 @@ esp_err_t SensorControl::initialize_tof() {
                  config_.lidar_config.uart_rx_pin,
                  config_.lidar_config.uart_tx_pin,
                  static_cast<unsigned long>(config_.lidar_config.baud_rate));
+#endif
     } else {
         latest_data_.lidar_measurement.active = false;
     }
@@ -138,10 +154,19 @@ esp_err_t SensorControl::initialize() {
         return err;
     }
 
+#if SHELFBOT_HAS_TOF
     err = initialize_tof();
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "TOF initialization failed");
         ESP_LOGW(TAG, "Continuing without TOF sensors");
+    }
+#else
+    ESP_LOGW(TAG, "TOF category disabled at compile-time (SHELFBOT_HAS_TOF=0)");
+#endif
+
+    err = initialize_lidar();
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "LiDAR initialization had errors; continuing without LiDAR");
     }
 
     initialized_ = true;
@@ -173,7 +198,22 @@ esp_err_t SensorControl::update_lidar_measurement() {
         latest_data_.lidar_measurement.health = 2;
         return ESP_ERR_INVALID_STATE;
     }
-    return lidar_sensor_->read(latest_data_.lidar_measurement);
+    esp_err_t err = lidar_sensor_->read(latest_data_.lidar_measurement);
+    if (err == ESP_OK) {
+        uint32_t count = lidar_sensor_->packet_count();
+        if (count > 0 && (count % 20) == 0) {
+            uint8_t raw[47];
+            if (lidar_sensor_->get_last_raw_packet(raw, sizeof(raw))) {
+                LidarParsedPacket parsed{};
+                if (LidarPacketParser::parse(raw, sizeof(raw), parsed)) {
+                    ESP_LOGW(TAG, "=== LiDAR RAW PACKET #%lu BEGIN ===", static_cast<unsigned long>(count));
+                    ESP_LOGW(TAG, "%s", parsed.json.c_str());
+                    ESP_LOGW(TAG, "=== LiDAR RAW PACKET #%lu END ===", static_cast<unsigned long>(count));
+                }
+            }
+        }
+    }
+    return err;
 }
 
 bool SensorControl::is_ready() const {
@@ -275,11 +315,13 @@ void SensorControl::continuous_read_loop() {
 
             // Read ToF sensors
             SensorCommon::TofMeasurement tof_results[SensorCommon::NUM_TOF_SENSORS];
+#if SHELFBOT_HAS_TOF
             if (tof_sensor_ && tof_sensor_->read_all(tof_results) == ESP_OK) {
                 for (int i = 0; i < SensorCommon::NUM_TOF_SENSORS; i++) {
                     latest_data_.tof_measurements[i] = tof_results[i];
                 }
             }
+#endif
 
             latest_data_.timestamp_us = timestamp;
             update_lidar_measurement();

--- a/components/sensor_control/sensor_manager.cpp
+++ b/components/sensor_control/sensor_manager.cpp
@@ -34,14 +34,17 @@ void SensorManager::monitor_loop() {
             }
 
             ESP_LOGI(TAG,
-                     "Snapshot us=%lld | US[%.1f, %.1f, %.1f, %.1f] cm | TOF[%s] mm valid[%s]",
+                     "Snapshot us=%lld | US[%.1f, %.1f, %.1f, %.1f] cm | TOF[%s] mm valid[%s] | LiDAR[%u]mm valid[%d] st[%u]",
                      static_cast<long long>(snapshot.timestamp_us),
                      snapshot.ultrasonic_readings[0].distance_cm,
                      snapshot.ultrasonic_readings[1].distance_cm,
                      snapshot.ultrasonic_readings[2].distance_cm,
                      snapshot.ultrasonic_readings[3].distance_cm,
                      tof_distance_stream.str().c_str(),
-                     tof_valid_stream.str().c_str());
+                     tof_valid_stream.str().c_str(),
+                     static_cast<unsigned>(snapshot.lidar_measurement.distance_mm),
+                     static_cast<int>(snapshot.lidar_measurement.valid),
+                     static_cast<unsigned>(snapshot.lidar_measurement.status));
             monitor_line_counter++;
             if (monitor_line_counter % 40 == 0) {
                 ESP_LOGI(TAG, "Firmware Version (every 40 lines): %s", FirmwareVersion::get_version_string());
@@ -91,6 +94,15 @@ void SensorManager::initialize(const SensorControl::Config& config) {
                 for (int i = 0; i < SensorCommon::NUM_TOF_SENSORS; i++) {
                     latest_data_.tof_measurements[i] = measurements[i];
                 }
+                latest_data_.timestamp_us = esp_timer_get_time();
+                xSemaphoreGive(data_mutex_);
+            }
+        };
+
+    config_with_callbacks.lidar_callback =
+        [this](const SensorCommon::LidarMeasurement& measurement) {
+            if (xSemaphoreTake(data_mutex_, pdMS_TO_TICKS(10)) == pdTRUE) {
+                latest_data_.lidar_measurement = measurement;
                 latest_data_.timestamp_us = esp_timer_get_time();
                 xSemaphoreGive(data_mutex_);
             }

--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -352,13 +352,21 @@ void Shelfbot::begin() {
         {.trig_pin = 32, .echo_pin = 33, .timeout_us = 30000, .max_distance_mm = 4000}
     };
 
-    // Configure 3 ToF sensors
+    // Configure ToF sensors (disabled: no ToF devices connected)
     for (int i = 0; i < SensorCommon::NUM_TOF_SENSORS; i++) {
         sensor_config.tof_configs[i].timeout_ms = 500;
+        sensor_config.tof_configs[i].enabled = false;
     }
 
     sensor_config.ultrasonic_read_interval_ms = 100;
     sensor_config.tof_read_interval_ms = 200;
+
+    // Configure LYDSTO LiDAR over UART (RX on GPIO3)
+    sensor_config.lidar_config.enabled = true;
+    sensor_config.lidar_config.uart_port = UART_NUM_2;
+    sensor_config.lidar_config.uart_tx_pin = UART_PIN_NO_CHANGE;
+    sensor_config.lidar_config.uart_rx_pin = GPIO_NUM_3;
+    sensor_config.lidar_config.baud_rate = 115200;
 
     // Initialize the global sensor manager
     SensorManager::get_instance().initialize(sensor_config);


### PR DESCRIPTION
### Motivation
- Provide a built-in web-based LiDAR live visualization and integrate LiDAR scan metadata into the existing HTTP API for easier debugging and inspection.
- Improve robustness of the LYDSTO UART driver by implementing a proper packet parser, CRC checking, buffering, and richer telemetry for diagnosing UART/frame issues.
- Surface scan angle information (start/end/min-angle) through the sensor pipeline so UI and logs can present spatial context for LiDAR readings.

### Description
- HTTP server: added `lidar.html` and `lidar_viz.js` static assets (registered via `target_add_binary_data`) and new handlers `lidar_page_handler` and `lidar_js_handler` for `/lidar.html` and `/lidar_viz.js`, plus a link to the LiDAR viewer on the main dashboard.
- Sensor JSON/API: included `start_angle_deg`, `end_angle_deg`, and `min_distance_angle_deg` in LiDAR JSON responses (`/api/lidar` and sensor aggregate JSON) and updated `SensorCommon::LidarMeasurement` to carry these fields.
- LYDSTO driver: rewrote the driver to handle 47-byte frames, added CRC8 validation, streaming buffer parsing, packet logging, retention of the last valid packet (`get_last_packet`), packet counters/telemetry, and a parameterized constructor for UART settings.
- Parsing and integration: added `LidarPacketParser` and parsing logic that can render a JSON summary of raw packets; updated `LidarSensor` and `SensorControl` to initialize/read the LiDAR, publish parsed packet logs periodically, and feed angle metadata into the shared `SensorDataPacket` and callbacks.
- Build/config changes: added `lidar.html`/`lidar_viz.js` to `components/http_server/CMakeLists.txt`, added `lidar_packet_parser.cpp` to the sensor component, and adjusted compile-time driver flags in `sensor_control/include/sensor_control.h` alongside new sensor initialization flow in `SensorControl` and wiring in `Shelfbot::begin`.

### Testing
- Built the firmware with `idf.py build` to verify compilation of the modified HTTP server, sensor, and driver components, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90da32e188322a25cebc624de5a76)