### PR TITLE
Use micro-ROS UDP in docs and align motor ROS topics to 5 axes

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -92,11 +92,13 @@ idf.py -p /dev/ttyUSB0 flash
 idf.py monitor
 ```
 
-### 1.11 Run micro‑ROS Agent (on host PC)
+### 1.11 Run micro‑ROS Agent (on host PC, UDP over IP)
 
 ```bash
-docker run -it --rm --net=host microros/micro-ros-agent:humble serial --dev /dev/ttyUSB0 -v6
+docker run -it --rm --net=host microros/micro-ros-agent:humble udp4 --port 8888 -v6
 ```
+
+> The firmware uses `rmw_uros_options_set_udp_address(..., "8888", ...)`, so transport is **UDP/IP** (not serial).
 
 ### 1.12 Full Clean Rebuild
 
@@ -214,6 +216,30 @@ GND             --------------------> GND (logic)
 | Ultrasonic pins    | ✅ Yes        | Verified against `shelfbot.cpp`          |
 | LiDAR pin (GPIO3)  | ⚠️ Conflict   | May conflict with console                |
 | LED pin            | ❌ Missing    | Check `led_control` for actual GPIO     |
-| Environment setup  | ✅ Correct    | Includes empy pin, flash size, partition|
+| Environment setup  | ✅ Correct    | Uses UDP micro‑ROS agent, flash size, partition |
 
 **The system is ready for deployment after resolving the LED pin and potential UART conflict.**
+
+---
+
+## 5. ROS 2 Interface Verification (from firmware code)
+
+Node name: `shelfbot_firmware`
+
+### Publishers (ESP32 → ROS 2)
+
+| Topic | Type | Payload details |
+|---|---|---|
+| `shelfbot_firmware/heartbeat` | `std_msgs/msg/Int32` | Increments every 1 second |
+| `shelfbot_firmware/motor_positions` | `std_msgs/msg/Float32MultiArray` | **5 values** (radians), one per motor index 0..4 |
+| `shelfbot_firmware/distance_sensors` | `std_msgs/msg/Float32MultiArray` | Up to 6 values (cm): 4 ultrasonic + 1 ToF + 1 LiDAR (`-1.0` if invalid) |
+| `shelfbot_firmware/led_state` | `std_msgs/msg/Bool` | Current LED state |
+| `shelfbot_firmware/tof_distance` | `std_msgs/msg/Float32` | ToF[0] distance in cm (`-1.0` if invalid/unavailable) |
+
+### Subscriptions (ROS 2 → ESP32)
+
+| Topic | Type | Payload details |
+|---|---|---|
+| `shelfbot_firmware/motor_command` | `std_msgs/msg/Float32MultiArray` | Position commands in radians; consumes up to first 5 elements |
+| `shelfbot_firmware/set_speed` | `std_msgs/msg/Float32MultiArray` | Velocity commands in rad/s; consumes up to first 5 elements |
+| `shelfbot_firmware/led` | `std_msgs/msg/Bool` | `true` = LED ON, `false` = LED OFF |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This document gives an overview of the project and points to detailed setup guid
 
 5. **Start the micro‑ROS agent** (on your PC):
    ```bash
-   docker run -it --rm --net=host microros/micro-ros-agent:humble serial --dev /dev/ttyUSB0 -v6
+   docker run -it --rm --net=host microros/micro-ros-agent:humble udp4 --port 8888 -v6
    ```
 
 ---
@@ -125,6 +125,28 @@ For full details, see [`MOTOR_SETUP.md`](MOTOR_SETUP.md). Here is a quick refere
 | LED (if used)     | Depends on `led_control` component   |
 
 **Important:** GPIO3 is also the default UART0 RX (console). If you need both the console and LiDAR, either move LiDAR to UART1 (pins 9/10) or disable the console on GPIO3 (change UART console to another UART in menuconfig).
+
+---
+
+## ROS 2 Topics (verified)
+
+### Published by firmware
+
+| Topic | Type | Notes |
+|---|---|---|
+| `shelfbot_firmware/heartbeat` | `std_msgs/msg/Int32` | 1 Hz heartbeat counter |
+| `shelfbot_firmware/motor_positions` | `std_msgs/msg/Float32MultiArray` | 5 motor positions in radians (indices 0..4) |
+| `shelfbot_firmware/distance_sensors` | `std_msgs/msg/Float32MultiArray` | Sensor distances in cm: 4 ultrasonic + 1 ToF + 1 LiDAR |
+| `shelfbot_firmware/led_state` | `std_msgs/msg/Bool` | Current LED state |
+| `shelfbot_firmware/tof_distance` | `std_msgs/msg/Float32` | ToF[0] in cm (`-1` when invalid) |
+
+### Subscribed by firmware
+
+| Topic | Type | Notes |
+|---|---|---|
+| `shelfbot_firmware/motor_command` | `std_msgs/msg/Float32MultiArray` | Position targets in radians; first 5 entries are used |
+| `shelfbot_firmware/set_speed` | `std_msgs/msg/Float32MultiArray` | Velocity targets in rad/s; first 5 entries are used |
+| `shelfbot_firmware/led` | `std_msgs/msg/Bool` | LED ON/OFF command |
 
 ---
 

--- a/components/shelfbot/include/shelfbot.hpp
+++ b/components/shelfbot/include/shelfbot.hpp
@@ -69,7 +69,7 @@ private:
     std_msgs__msg__Float32MultiArray set_speed_msg{};
     std_msgs__msg__Bool led_msg{};
 
-    float motor_pos_data[2]{};
+    float motor_pos_data[NUM_MOTORS]{};
     float distance_sensors_data[SensorCommon::NUM_SENSORS]{};
 
     std::unique_ptr<SensorControl> sensor_control_ = {

--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -69,9 +69,10 @@ void Shelfbot::heartbeat_timer_callback(rcl_timer_t * timer, int64_t last_call_t
 void Shelfbot::motor_position_timer_callback(rcl_timer_t * timer, int64_t last_call_time) {
     (void) last_call_time;
     if (timer != NULL) {
-        motor_pos_data[0] = motor_control_get_position(0);
-        motor_pos_data[1] = motor_control_get_position(1);
-        motor_position_msg.data.size = 2;
+        for (uint8_t i = 0; i < NUM_MOTORS; i++) {
+            motor_pos_data[i] = static_cast<float>(motor_control_get_position(i));
+        }
+        motor_position_msg.data.size = NUM_MOTORS;
         RCSOFTCHECK(rcl_publish(&motor_position_publisher, &motor_position_msg, NULL));
     }
 }
@@ -128,17 +129,17 @@ void Shelfbot::tof_timer_callback(rcl_timer_t * timer, int64_t last_call_time) {
 // --- ROS Subscription Callbacks ---
 void Shelfbot::motor_command_subscription_callback(const void * msin) {
     const std_msgs__msg__Float32MultiArray * msg = (const std_msgs__msg__Float32MultiArray *)msin;
-    if (msg->data.size >= 2) {
-        motor_control_set_position(0, msg->data.data[0]);
-        motor_control_set_position(1, msg->data.data[1]);
+    const size_t count = std::min(static_cast<size_t>(NUM_MOTORS), msg->data.size);
+    for (size_t i = 0; i < count; i++) {
+        motor_control_set_position(static_cast<uint8_t>(i), msg->data.data[i]);
     }
 }
 
 void Shelfbot::set_speed_subscription_callback(const void * msin) {
     const std_msgs__msg__Float32MultiArray * msg = (const std_msgs__msg__Float32MultiArray *)msin;
-    if (msg->data.size >= 2) {
-         motor_control_set_velocity(0, msg->data.data[0]);
-         motor_control_set_velocity(1, msg->data.data[1]);
+    const size_t count = std::min(static_cast<size_t>(NUM_MOTORS), msg->data.size);
+    for (size_t i = 0; i < count; i++) {
+        motor_control_set_velocity(static_cast<uint8_t>(i), msg->data.data[i]);
     }
 }
 
@@ -194,7 +195,7 @@ void Shelfbot::create_entities() {
     RCCHECK(rclc_executor_add_subscription(&executor, &set_speed_subscription, &set_speed_msg, &set_speed_subscription_callback_wrapper, ON_NEW_DATA));
     RCCHECK(rclc_executor_add_subscription(&executor, &led_subscription, &led_msg, &led_subscription_callback_wrapper, ON_NEW_DATA));
 
-    init_multi_array(motor_position_msg, motor_pos_data, 2);
+    init_multi_array(motor_position_msg, motor_pos_data, NUM_MOTORS);
     init_multi_array(distance_sensors_msg, distance_sensors_data, SensorCommon::NUM_SENSORS);
 }
 


### PR DESCRIPTION
### Motivation
- The environment docs incorrectly instructed running the micro‑ROS agent over a serial bridge while the firmware configures UDP transport via `rmw_uros_options_set_udp_address(..., "8888", ...)`, so the docs needed to match runtime behavior.
- The firmware and documentation described ROS motor topics as handling only two axes while the hardware and motor control code define `NUM_MOTORS==5`, so message sizes and handling needed to be aligned.
- The change also consolidates verified ROS 2 topic contracts (publishers/subscriptions) for sensors, motors, and LED to avoid future mismatches.

### Description
- Updated `ENVIRONMENT_SETUP.md` and `README.md` quick-starts to use the micro‑ROS agent over UDP (`docker run ... microros/micro-ros-agent:humble udp4 --port 8888 -v6`) and added a note that the firmware uses UDP port `8888` via `rmw_uros_options_set_udp_address`.
- Added ROS 2 topic verification tables to `ENVIRONMENT_SETUP.md` and `README.md` listing node name `shelfbot_firmware`, published topics (`heartbeat`, `motor_positions`, `distance_sensors`, `led_state`, `tof_distance`) and subscribed topics (`motor_command`, `set_speed`, `led`) with message types and payload semantics.
- Aligned firmware to 5 motors by changing `motor_pos_data` capacity to `NUM_MOTORS` in `components/shelfbot/include/shelfbot.hpp` and initializing the publisher multi-array with `NUM_MOTORS` capacity.
- Modified `components/shelfbot/shelfbot.cpp` so `motor_positions` now publishes all `NUM_MOTORS` positions, and `motor_command`/`set_speed` callbacks iterate up to `NUM_MOTORS` elements when applying position/velocity commands.

### Testing
- Searched and inspected relevant files to verify changes with `rg`/`sed`/`nl` commands, confirming the agent command and topic names were updated in `ENVIRONMENT_SETUP.md`, `README.md`, and `components/shelfbot/shelfbot.cpp`, and these inspections completed successfully.
- Ran `git diff` to review code changes and committed the updates with a successful `git commit` message stating the intent of the modifications.
- No firmware build or runtime integration tests were executed in this PR; functional verification on hardware or a running micro‑ROS agent is recommended to validate runtime UDP connectivity and ROS message behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f649003408322818164100dc71789)