### PR TITLE
Publish full NUM_MOTORS positions, switch micro-ROS to UDP, and harden VL53L0X error handling

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -92,11 +92,13 @@ idf.py -p /dev/ttyUSB0 flash
 idf.py monitor
 ```
 
-### 1.11 Run micro‑ROS Agent (on host PC)
+### 1.11 Run micro‑ROS Agent (on host PC, UDP over IP)
 
 ```bash
-docker run -it --rm --net=host microros/micro-ros-agent:humble serial --dev /dev/ttyUSB0 -v6
+docker run -it --rm --net=host microros/micro-ros-agent:humble udp4 --port 8888 -v6
 ```
+
+> The firmware uses `rmw_uros_options_set_udp_address(..., "8888", ...)`, so transport is **UDP/IP** (not serial).
 
 ### 1.12 Full Clean Rebuild
 
@@ -214,6 +216,30 @@ GND             --------------------> GND (logic)
 | Ultrasonic pins    | ✅ Yes        | Verified against `shelfbot.cpp`          |
 | LiDAR pin (GPIO3)  | ⚠️ Conflict   | May conflict with console                |
 | LED pin            | ❌ Missing    | Check `led_control` for actual GPIO     |
-| Environment setup  | ✅ Correct    | Includes empy pin, flash size, partition|
+| Environment setup  | ✅ Correct    | Uses UDP micro‑ROS agent, flash size, partition |
 
 **The system is ready for deployment after resolving the LED pin and potential UART conflict.**
+
+---
+
+## 5. ROS 2 Interface Verification (from firmware code)
+
+Node name: `shelfbot_firmware`
+
+### Publishers (ESP32 → ROS 2)
+
+| Topic | Type | Payload details |
+|---|---|---|
+| `shelfbot_firmware/heartbeat` | `std_msgs/msg/Int32` | Increments every 1 second |
+| `shelfbot_firmware/motor_positions` | `std_msgs/msg/Float32MultiArray` | **5 values** (radians), one per motor index 0..4 |
+| `shelfbot_firmware/distance_sensors` | `std_msgs/msg/Float32MultiArray` | Up to 6 values (cm): 4 ultrasonic + 1 ToF + 1 LiDAR (`-1.0` if invalid) |
+| `shelfbot_firmware/led_state` | `std_msgs/msg/Bool` | Current LED state |
+| `shelfbot_firmware/tof_distance` | `std_msgs/msg/Float32` | ToF[0] distance in cm (`-1.0` if invalid/unavailable) |
+
+### Subscriptions (ROS 2 → ESP32)
+
+| Topic | Type | Payload details |
+|---|---|---|
+| `shelfbot_firmware/motor_command` | `std_msgs/msg/Float32MultiArray` | Position commands in radians; consumes up to first 5 elements |
+| `shelfbot_firmware/set_speed` | `std_msgs/msg/Float32MultiArray` | Velocity commands in rad/s; consumes up to first 5 elements |
+| `shelfbot_firmware/led` | `std_msgs/msg/Bool` | `true` = LED ON, `false` = LED OFF |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This document gives an overview of the project and points to detailed setup guid
 
 5. **Start the micro‑ROS agent** (on your PC):
    ```bash
-   docker run -it --rm --net=host microros/micro-ros-agent:humble serial --dev /dev/ttyUSB0 -v6
+   docker run -it --rm --net=host microros/micro-ros-agent:humble udp4 --port 8888 -v6
    ```
 
 ---
@@ -125,6 +125,28 @@ For full details, see [`MOTOR_SETUP.md`](MOTOR_SETUP.md). Here is a quick refere
 | LED (if used)     | Depends on `led_control` component   |
 
 **Important:** GPIO3 is also the default UART0 RX (console). If you need both the console and LiDAR, either move LiDAR to UART1 (pins 9/10) or disable the console on GPIO3 (change UART console to another UART in menuconfig).
+
+---
+
+## ROS 2 Topics (verified)
+
+### Published by firmware
+
+| Topic | Type | Notes |
+|---|---|---|
+| `shelfbot_firmware/heartbeat` | `std_msgs/msg/Int32` | 1 Hz heartbeat counter |
+| `shelfbot_firmware/motor_positions` | `std_msgs/msg/Float32MultiArray` | 5 motor positions in radians (indices 0..4) |
+| `shelfbot_firmware/distance_sensors` | `std_msgs/msg/Float32MultiArray` | Sensor distances in cm: 4 ultrasonic + 1 ToF + 1 LiDAR |
+| `shelfbot_firmware/led_state` | `std_msgs/msg/Bool` | Current LED state |
+| `shelfbot_firmware/tof_distance` | `std_msgs/msg/Float32` | ToF[0] in cm (`-1` when invalid) |
+
+### Subscribed by firmware
+
+| Topic | Type | Notes |
+|---|---|---|
+| `shelfbot_firmware/motor_command` | `std_msgs/msg/Float32MultiArray` | Position targets in radians; first 5 entries are used |
+| `shelfbot_firmware/set_speed` | `std_msgs/msg/Float32MultiArray` | Velocity targets in rad/s; first 5 entries are used |
+| `shelfbot_firmware/led` | `std_msgs/msg/Bool` | LED ON/OFF command |
 
 ---
 

--- a/components/motor_control/motor_control.cpp
+++ b/components/motor_control/motor_control.cpp
@@ -130,7 +130,21 @@ void motor_control_set_velocity(const uint8_t index, const double velocity_rad_s
 }
 
 void motor_control_set_position(const uint8_t index, const double position_rad) {
-    motor_control_apply(index, position_rad, 0.0);
+    if (index >= NUM_MOTORS || !steppers[index]) return;
+
+    const long target_steps = static_cast<long>(position_rad * RADS_TO_STEPS);
+    const long current_steps = steppers[index]->getCurrentPosition();
+    if (target_steps > current_steps) {
+        motor_direction_sign[index] = 1;
+    } else if (target_steps < current_steps) {
+        motor_direction_sign[index] = -1;
+    } else {
+        motor_direction_sign[index] = 0;
+    }
+
+    steppers[index]->setSpeedInHz(DEFAULT_SPEED_HZ);
+    steppers[index]->setAcceleration(DEFAULT_ACCEL_HZ_S);
+    steppers[index]->moveTo(target_steps);
 }
 
 // ---------------------------------------------------------------------------

--- a/components/shelfbot/include/shelfbot.hpp
+++ b/components/shelfbot/include/shelfbot.hpp
@@ -69,7 +69,7 @@ private:
     std_msgs__msg__Float32MultiArray set_speed_msg{};
     std_msgs__msg__Bool led_msg{};
 
-    float motor_pos_data[2]{};
+    float motor_pos_data[NUM_MOTORS]{};
     float distance_sensors_data[SensorCommon::NUM_SENSORS]{};
 
     std::unique_ptr<SensorControl> sensor_control_ = {

--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -69,9 +69,10 @@ void Shelfbot::heartbeat_timer_callback(rcl_timer_t * timer, int64_t last_call_t
 void Shelfbot::motor_position_timer_callback(rcl_timer_t * timer, int64_t last_call_time) {
     (void) last_call_time;
     if (timer != NULL) {
-        motor_pos_data[0] = motor_control_get_position(0);
-        motor_pos_data[1] = motor_control_get_position(1);
-        motor_position_msg.data.size = 2;
+        for (uint8_t i = 0; i < NUM_MOTORS; i++) {
+            motor_pos_data[i] = static_cast<float>(motor_control_get_position(i));
+        }
+        motor_position_msg.data.size = NUM_MOTORS;
         RCSOFTCHECK(rcl_publish(&motor_position_publisher, &motor_position_msg, NULL));
     }
 }
@@ -128,17 +129,17 @@ void Shelfbot::tof_timer_callback(rcl_timer_t * timer, int64_t last_call_time) {
 // --- ROS Subscription Callbacks ---
 void Shelfbot::motor_command_subscription_callback(const void * msin) {
     const std_msgs__msg__Float32MultiArray * msg = (const std_msgs__msg__Float32MultiArray *)msin;
-    if (msg->data.size >= 2) {
-        motor_control_set_position(0, msg->data.data[0]);
-        motor_control_set_position(1, msg->data.data[1]);
+    const size_t count = std::min(static_cast<size_t>(NUM_MOTORS), msg->data.size);
+    for (size_t i = 0; i < count; i++) {
+        motor_control_set_position(static_cast<uint8_t>(i), msg->data.data[i]);
     }
 }
 
 void Shelfbot::set_speed_subscription_callback(const void * msin) {
     const std_msgs__msg__Float32MultiArray * msg = (const std_msgs__msg__Float32MultiArray *)msin;
-    if (msg->data.size >= 2) {
-         motor_control_set_velocity(0, msg->data.data[0]);
-         motor_control_set_velocity(1, msg->data.data[1]);
+    const size_t count = std::min(static_cast<size_t>(NUM_MOTORS), msg->data.size);
+    for (size_t i = 0; i < count; i++) {
+        motor_control_set_velocity(static_cast<uint8_t>(i), msg->data.data[i]);
     }
 }
 
@@ -194,7 +195,7 @@ void Shelfbot::create_entities() {
     RCCHECK(rclc_executor_add_subscription(&executor, &set_speed_subscription, &set_speed_msg, &set_speed_subscription_callback_wrapper, ON_NEW_DATA));
     RCCHECK(rclc_executor_add_subscription(&executor, &led_subscription, &led_msg, &led_subscription_callback_wrapper, ON_NEW_DATA));
 
-    init_multi_array(motor_position_msg, motor_pos_data, 2);
+    init_multi_array(motor_position_msg, motor_pos_data, NUM_MOTORS);
     init_multi_array(distance_sensors_msg, distance_sensors_data, SensorCommon::NUM_SENSORS);
 }
 

--- a/components/vl53l0x_driver/vl53l0x.cpp
+++ b/components/vl53l0x_driver/vl53l0x.cpp
@@ -858,7 +858,7 @@ const char* VL53L0X_Driver::calibrate() {
     }
     ESP_LOGI(TAG, "Running calibrations...");
     if (ESP_OK != writeReg8(Reg::SYSTEM_SEQUENCE_CONFIG, 0x01)) {
-       return nullptr;
+       return "Failed to write SYSTEM_SEQUENCE_CONFIG (VHV)";
     }
     esp_err_t err = performSingleRefCalibration(0x40);
     if (err != ESP_OK) {
@@ -868,7 +868,7 @@ const char* VL53L0X_Driver::calibrate() {
     ESP_LOGI(TAG, "VHV calibration OK");
 
     if (ESP_OK != writeReg8(Reg::SYSTEM_SEQUENCE_CONFIG, 0x02)) {
-        return nullptr;
+        return "Failed to write SYSTEM_SEQUENCE_CONFIG (phase)";
     }
     err = performSingleRefCalibration(0x00);
     if (err != ESP_OK) {
@@ -878,7 +878,7 @@ const char* VL53L0X_Driver::calibrate() {
     ESP_LOGI(TAG, "Phase calibration OK");
 
     if (ESP_OK != writeReg8(Reg::SYSTEM_SEQUENCE_CONFIG, 0xE8)) {
-        return nullptr;
+        return "Failed to restore SYSTEM_SEQUENCE_CONFIG";
     }
 
     ESP_LOGI(TAG, "Calibration complete");
@@ -914,28 +914,36 @@ bool VL53L0X_Driver::read_sensor(MeasurementResult& result) {
 
     // Prepare for measurement
     if (ESP_OK != writeReg8(0x80, 0x01)) {
+       unlockI2C();
        return false;
     }
     if (ESP_OK != writeReg8(0xFF, 0x01)) {
+        unlockI2C();
         return false;
     }
     if (ESP_OK != writeReg8(0x00, 0x00)) {
+        unlockI2C();
         return false;
     }
     if (ESP_OK != writeReg8(0x91, stop_variable_)) {
+        unlockI2C();
         return false;
     }
     if (ESP_OK != writeReg8(0x00, 0x01)) {
+        unlockI2C();
         return false;
     }
     if (ESP_OK != writeReg8(0xFF, 0x00)) {
+        unlockI2C();
         return false;
     }
     if (ESP_OK != writeReg8(0x80, 0x00)) {
+        unlockI2C();
         return false;
     }
     // Start measurement
     if (ESP_OK != writeReg8(Reg::SYSRANGE_START, 0x01)) {
+        unlockI2C();
         return false;
     }
 


### PR DESCRIPTION
### Motivation

- Expand firmware to handle a configurable number of motors (`NUM_MOTORS`) instead of a fixed two-element array and ensure ROS topics reflect the full motor set. 
- Update documentation and agent startup to use UDP/IP transport as configured by the firmware. 
- Improve robustness of the VL53L0X driver by returning explicit errors from calibration and ensuring I2C locks are always released on failure.

### Description

- Updated documentation in `ENVIRONMENT_SETUP.md` and `README.md` to use the UDP micro‑ROS agent invocation (`docker run ... udp4 --port 8888`) and added a note that the firmware uses `rmw_uros_options_set_udp_address(..., "8888", ...)` for UDP transport. 
- Added a new ROS 2 topics summary to `ENVIRONMENT_SETUP.md` and `README.md` documenting published and subscribed topics and payload details. 
- Replaced fixed-size motor arrays with `NUM_MOTORS` in `shelfbot.hpp` and adjusted `shelfbot.cpp` to publish `NUM_MOTORS` positions and to iterate safely over incoming multi-array commands for both position and speed. 
- Changed `motor_control_set_position` in `motor_control.cpp` to validate index bounds, compute and set direction, set default speed/acceleration, and call `moveTo` directly (removing the previous wrapper call). 
- Hardened `vl53l0x.cpp` by returning descriptive error strings from `calibrate()` when register writes fail and by calling `unlockI2C()` before all early returns in `read_sensor()` to avoid leaving the bus locked.

### Testing

- Performed an automated firmware build with `idf.py build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f649003408322818164100dc71789)