### PR TITLE
Make micro-ROS agent mDNS host configurable

### DIFF
--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -257,7 +257,7 @@ void Shelfbot::micro_ros_task_impl() {
     while(1) {
         switch(state) {
             case WAITING_AGENT:
-                if (query_mdns_host("gentoo-laptop")) {
+                if (query_mdns_host(CONFIG_MICROROS_AGENT_MDNS_HOST)) {
                     rcl_ret_t ret = rcl_init_options_init(&init_options, allocator);
                     if (ret != RCL_RET_OK) {
                         ESP_LOGE(TAG, "Failed to init rcl init options: %ld", ret);
@@ -271,6 +271,8 @@ void Shelfbot::micro_ros_task_impl() {
                     if (ret != RCL_RET_OK) {
                         ESP_LOGE(TAG, "Failed to finalize rcl init options: %ld", ret);
                     }
+                } else {
+                    ESP_LOGW(TAG, "micro-ROS agent not found via mDNS host '%s.local'", CONFIG_MICROROS_AGENT_MDNS_HOST);
                 }
                 vTaskDelay(pdMS_TO_TICKS(2000));
                 break;

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -77,3 +77,12 @@ menu "Wi-Fi Configuration"
             When no known AP is visible, wait this many seconds before rescanning.
 
 endmenu
+
+menu "micro-ROS Configuration"
+    config MICROROS_AGENT_MDNS_HOST
+        string "micro-ROS agent mDNS hostname"
+        default "gentoo-laptop"
+        help
+            mDNS hostname (without .local) used by firmware to discover the micro-ROS agent.
+            Example: set to "burger-desktop" for burger-desktop.local.
+endmenu


### PR DESCRIPTION
### Motivation
- The firmware previously used a hard-coded mDNS name (`gentoo-laptop`) when discovering the micro-ROS agent, preventing discovery when the agent runs on a differently-named host. 
- Making the hostname configurable enables discovery on other machines (for example `burger-desktop`) without code changes.

### Description
- Add a new `MICROROS_AGENT_MDNS_HOST` Kconfig option under a `micro-ROS Configuration` menu in `main/Kconfig.projbuild` with default `"gentoo-laptop"`.
- Replace the hard-coded `"gentoo-laptop"` call in `components/shelfbot/shelfbot.cpp` with `CONFIG_MICROROS_AGENT_MDNS_HOST` for mDNS discovery.
- Add a warning log when mDNS discovery fails for the configured host to make failures visible in serial logs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a106baa274c8322b4827508fd831484)