### PR TITLE
Make micro-ROS agent mDNS host configurable and harden Wi-Fi manager

### DIFF
--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -257,7 +257,7 @@ void Shelfbot::micro_ros_task_impl() {
     while(1) {
         switch(state) {
             case WAITING_AGENT:
-                if (query_mdns_host("gentoo-laptop")) {
+                if (query_mdns_host(CONFIG_MICROROS_AGENT_MDNS_HOST)) {
                     rcl_ret_t ret = rcl_init_options_init(&init_options, allocator);
                     if (ret != RCL_RET_OK) {
                         ESP_LOGE(TAG, "Failed to init rcl init options: %ld", ret);
@@ -271,6 +271,8 @@ void Shelfbot::micro_ros_task_impl() {
                     if (ret != RCL_RET_OK) {
                         ESP_LOGE(TAG, "Failed to finalize rcl init options: %ld", ret);
                     }
+                } else {
+                    ESP_LOGW(TAG, "micro-ROS agent not found via mDNS host '%s.local'", CONFIG_MICROROS_AGENT_MDNS_HOST);
                 }
                 vTaskDelay(pdMS_TO_TICKS(2000));
                 break;

--- a/components/wifi_manager/wifi_manager.cpp
+++ b/components/wifi_manager/wifi_manager.cpp
@@ -17,6 +17,14 @@ static constexpr cred_t s_creds[] = {
 static constexpr int CRED_COUNT = static_cast<int>(std::size(s_creds));
 static_assert(CRED_COUNT > 0, "no credential slots defined");  // guardrail
 
+static int valid_cred_count() {
+    int valid = 0;
+    for (int i = 0; i < CRED_COUNT; i++) {
+        if (s_creds[i].ssid && s_creds[i].ssid[0] != '\0') valid++;
+    }
+    return valid;
+}
+
 // -------------------------------------------------------------------
 // Tuning from Kconfig
 // -------------------------------------------------------------------
@@ -266,10 +274,18 @@ static bool monitor_rssi() {
 // Manager task
 // -------------------------------------------------------------------
 [[noreturn]] static void manager_task(void *arg) {
-    ESP_LOGI(TAG, "manager task started, %d credential slot(s)", CRED_COUNT);
+    ESP_LOGI(TAG, "manager task started, %d credential slot(s), %d configured",
+             CRED_COUNT, valid_cred_count());
     for (int i = 0; i < CRED_COUNT; i++) {
         if (s_creds[i].ssid && s_creds[i].ssid[0] != '\0')
             ESP_LOGI(TAG, "  [%d] \"%s\"", i, s_creds[i].ssid);
+        else
+            ESP_LOGI(TAG, "  [%d] <empty>", i);
+    }
+
+    if (valid_cred_count() == 0) {
+        ESP_LOGE(TAG, "no Wi-Fi SSIDs configured; set CONFIG_WIFI_SSID_1..4 in menuconfig");
+        vTaskDelete(nullptr);
     }
     int  ci        = -1;
     bool skip_scan = false;

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -77,3 +77,12 @@ menu "Wi-Fi Configuration"
             When no known AP is visible, wait this many seconds before rescanning.
 
 endmenu
+
+menu "micro-ROS Configuration"
+    config MICROROS_AGENT_MDNS_HOST
+        string "micro-ROS agent mDNS hostname"
+        default "gentoo-laptop"
+        help
+            mDNS hostname (without .local) used by firmware to discover the micro-ROS agent.
+            Example: set to "burger-desktop" for burger-desktop.local.
+endmenu


### PR DESCRIPTION
### Motivation
- Make the micro-ROS agent discovery hostname configurable instead of hardcoding `gentoo-laptop` so different deployments can locate the agent via mDNS. 
- Improve robustness and diagnostics in the Wi‑Fi manager by validating configured SSID slots and failing fast when no credentials are provided.

### Description
- Add a new Kconfig entry `MICROROS_AGENT_MDNS_HOST` (default `gentoo-laptop`) to allow configuring the micro-ROS agent mDNS hostname. 
- Replace the hardcoded mDNS host string in `Shelfbot::micro_ros_task_impl` with `CONFIG_MICROROS_AGENT_MDNS_HOST` and log a warning when the agent is not found via mDNS. 
- Introduce `valid_cred_count()` in `wifi_manager.cpp` to count non-empty credential slots and include this count in the manager startup log. 
- Log `<empty>` for unused credential slots and terminate the manager task with an error if no SSIDs are configured to avoid looping with no credentials.

### Testing
- Built the firmware with `idf.py build` and the build completed successfully. 
- Verified compile-time guards (`static_assert`s) remain satisfied during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a106baa274c8322b4827508fd831484)