### PR TITLE
Make micro-ROS agent host configurable; add diagnostic logs and Wi‑Fi credential validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,46 @@ Then rebuild.
 | Symptom                           | Likely solution                                                      |
 |-----------------------------------|----------------------------------------------------------------------|
 | `app partition is too small`      | Flash size not set to 4 MB (see ENVIRONMENT_SETUP.md step 1.8)       |
-| micro‑ROS agent connection fails  | Check that the agent uses `humble` and the correct serial port       |
+| micro‑ROS agent connection fails  | Verify UDP agent on port `8888`, mDNS host, and Wi‑Fi reachability   |
 | Wi‑Fi does not connect            | Verify SSID/password in menuconfig; check RSSI thresholds            |
 | Web interface not loading         | Check IP address; ensure HTTP server started (look for log message)  |
 | GPIO3 conflict (LiDAR + console)  | Move LiDAR to another UART or disable console on GPIO3               |
+
+---
+
+## micro-ROS lifecycle troubleshooting (logs + grep)
+
+Use these commands on your host log file (example: `cutecom.log`):
+
+```bash
+# 1) High-level lifecycle in order
+grep -nEi "Micro-ROS task waiting|Wi-Fi ready, starting Micro-ROS|Querying for mDNS host|mDNS Query Result|Failed to init rcl init options|create_entities|AGENT_CONNECTED|AGENT_DISCONNECTED" cutecom.log
+
+# 2) Focus on rcl/rmw errors with surrounding context
+grep -nEi -B4 -A6 "rcl|rmw|RCL_RET|Failed to init rcl" cutecom.log
+
+# 3) Confirm all entity creation logs
+grep -nEi "Created node|Created publishers|Created subscriptions|Executor configured|create_entities: complete" cutecom.log
+
+# 4) Confirm publisher activity
+grep -nEi "Published heartbeat|Published motor_positions|Published distance_sensors|Published led_state|Published tof_distance" cutecom.log
+
+# 5) Confirm subscriber activity (commands received)
+grep -nEi "Received motor_command|Received set_speed|Received led command" cutecom.log
+```
+
+Expected lifecycle:
+1. Wi‑Fi connects.
+2. mDNS resolves configured agent host (`<host>.local`) to IPv4.
+3. `rcl_init_options_init` succeeds.
+4. node + publishers + subscriptions + executor are created.
+5. publishers periodically post; subscriptions log inbound commands.
+
+If you repeatedly see `Failed to init rcl init options`, capture and compare:
+- Agent command line (`udp4 --port 8888 -v6`)
+- ESP32 Wi‑Fi IP/subnet
+- mDNS-resolved agent IPv4
+- Exact failing return code sequence in logs
 
 ---
 

--- a/components/shelfbot/shelfbot.cpp
+++ b/components/shelfbot/shelfbot.cpp
@@ -63,6 +63,7 @@ void Shelfbot::heartbeat_timer_callback(rcl_timer_t * timer, int64_t last_call_t
     if (timer != NULL) {
         heartbeat_msg.data++;
         RCSOFTCHECK(rcl_publish(&heartbeat_publisher, &heartbeat_msg, NULL));
+        ESP_LOGD(TAG, "Published heartbeat=%ld", static_cast<long>(heartbeat_msg.data));
     }
 }
 
@@ -74,6 +75,7 @@ void Shelfbot::motor_position_timer_callback(rcl_timer_t * timer, int64_t last_c
         }
         motor_position_msg.data.size = NUM_MOTORS;
         RCSOFTCHECK(rcl_publish(&motor_position_publisher, &motor_position_msg, NULL));
+        ESP_LOGD(TAG, "Published motor_positions count=%u", static_cast<unsigned>(motor_position_msg.data.size));
     }
 }
 
@@ -97,6 +99,7 @@ void Shelfbot::distance_sensors_timer_callback(rcl_timer_t * timer, int64_t last
             }
             distance_sensors_msg.data.size = idx;
             RCSOFTCHECK(rcl_publish(&distance_sensors_publisher, &distance_sensors_msg, NULL));
+            ESP_LOGD(TAG, "Published distance_sensors count=%u", static_cast<unsigned>(distance_sensors_msg.data.size));
         }
     }
 }
@@ -106,6 +109,7 @@ void Shelfbot::led_state_timer_callback(rcl_timer_t * timer, int64_t last_call_t
     if (timer != NULL) {
         led_state_msg.data = led_state;
         RCSOFTCHECK(rcl_publish(&led_state_publisher, &led_state_msg, NULL));
+        ESP_LOGD(TAG, "Published led_state=%d", static_cast<int>(led_state_msg.data));
     }
 }
 
@@ -123,6 +127,7 @@ void Shelfbot::tof_timer_callback(rcl_timer_t * timer, int64_t last_call_time) {
             tof_distance_msg.data = -1.0f;
         }
         RCSOFTCHECK(rcl_publish(&tof_distance_publisher, &tof_distance_msg, NULL));
+        ESP_LOGD(TAG, "Published tof_distance=%.2f", tof_distance_msg.data);
     }
 }
 
@@ -130,6 +135,7 @@ void Shelfbot::tof_timer_callback(rcl_timer_t * timer, int64_t last_call_time) {
 void Shelfbot::motor_command_subscription_callback(const void * msin) {
     const auto * msg = static_cast<const std_msgs__msg__Float32MultiArray *>(msin);
     const size_t count = std::min(static_cast<size_t>(NUM_MOTORS), msg->data.size);
+    ESP_LOGI(TAG, "Received motor_command count=%u", static_cast<unsigned>(count));
     for (size_t i = 0; i < count; i++) {
         motor_control_set_position(static_cast<uint8_t>(i), msg->data.data[i]);
     }
@@ -138,6 +144,7 @@ void Shelfbot::motor_command_subscription_callback(const void * msin) {
 void Shelfbot::set_speed_subscription_callback(const void * msin) {
     const auto * msg = static_cast<const std_msgs__msg__Float32MultiArray *>(msin);
     const size_t count = std::min(static_cast<size_t>(NUM_MOTORS), msg->data.size);
+    ESP_LOGI(TAG, "Received set_speed count=%u", static_cast<unsigned>(count));
     for (size_t i = 0; i < count; i++) {
         motor_control_set_velocity(static_cast<uint8_t>(i), msg->data.data[i]);
     }
@@ -147,6 +154,7 @@ void Shelfbot::led_subscription_callback(const void * msin) {
     const auto * msg = static_cast<const std_msgs__msg__Bool *>(msin);
     led_state = msg->data;
     led_control_set(led_state);
+    ESP_LOGI(TAG, "Received led command=%d", static_cast<int>(led_state));
 }
 
 // --- Static Callback Wrappers ---
@@ -162,19 +170,23 @@ void Shelfbot::micro_ros_task_wrapper(void * arg) { if(instance) instance->micro
 
 // --- Entity Lifecycle ---
 void Shelfbot::create_entities() {
+    ESP_LOGI(TAG, "Micro-ROS create_entities: begin");
     allocator = rcl_get_default_allocator();
     RCCHECK(rclc_support_init(&support, 0, NULL, &allocator));
     RCCHECK(rclc_node_init_default(&node, "shelfbot_firmware", "", &support));
+    ESP_LOGI(TAG, "Created node: shelfbot_firmware");
 
     RCCHECK(rclc_publisher_init_default(&heartbeat_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32), "shelfbot_firmware/heartbeat"));
     RCCHECK(rclc_publisher_init_default(&motor_position_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray), "shelfbot_firmware/motor_positions"));
     RCCHECK(rclc_publisher_init_default(&distance_sensors_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray), "shelfbot_firmware/distance_sensors"));
     RCCHECK(rclc_publisher_init_default(&led_state_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool), "shelfbot_firmware/led_state"));
     RCCHECK(rclc_publisher_init_default(&tof_distance_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32), "shelfbot_firmware/tof_distance"));
+    ESP_LOGI(TAG, "Created publishers: heartbeat, motor_positions, distance_sensors, led_state, tof_distance");
 
     RCCHECK(rclc_subscription_init_default(&motor_command_subscription, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray), "shelfbot_firmware/motor_command"));
     RCCHECK(rclc_subscription_init_default(&set_speed_subscription, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32MultiArray), "shelfbot_firmware/set_speed"));
     RCCHECK(rclc_subscription_init_default(&led_subscription, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool), "shelfbot_firmware/led"));
+    ESP_LOGI(TAG, "Created subscriptions: motor_command, set_speed, led");
 
     RCCHECK(rclc_timer_init_default(&heartbeat_timer, &support, RCL_MS_TO_NS(1000), heartbeat_timer_callback_wrapper));
     RCCHECK(rclc_timer_init_default(&motor_position_timer, &support, RCL_MS_TO_NS(100), motor_position_timer_callback_wrapper));
@@ -194,9 +206,11 @@ void Shelfbot::create_entities() {
     RCCHECK(rclc_executor_add_subscription(&executor, &motor_command_subscription, &motor_command_msg, &motor_command_subscription_callback_wrapper, ON_NEW_DATA));
     RCCHECK(rclc_executor_add_subscription(&executor, &set_speed_subscription, &set_speed_msg, &set_speed_subscription_callback_wrapper, ON_NEW_DATA));
     RCCHECK(rclc_executor_add_subscription(&executor, &led_subscription, &led_msg, &led_subscription_callback_wrapper, ON_NEW_DATA));
+    ESP_LOGI(TAG, "Executor configured with 5 timers + 3 subscriptions");
 
     init_multi_array(motor_position_msg, motor_pos_data, NUM_MOTORS);
     init_multi_array(distance_sensors_msg, distance_sensors_data, SensorCommon::NUM_SENSORS);
+    ESP_LOGI(TAG, "Micro-ROS create_entities: complete");
 }
 
 void Shelfbot::destroy_entities() {
@@ -257,7 +271,7 @@ void Shelfbot::micro_ros_task_impl() {
     while(1) {
         switch(state) {
             case WAITING_AGENT:
-                if (query_mdns_host("gentoo-laptop")) {
+                if (query_mdns_host(CONFIG_MICROROS_AGENT_MDNS_HOST)) {
                     rcl_ret_t ret = rcl_init_options_init(&init_options, allocator);
                     if (ret != RCL_RET_OK) {
                         ESP_LOGE(TAG, "Failed to init rcl init options: %ld", ret);
@@ -271,6 +285,8 @@ void Shelfbot::micro_ros_task_impl() {
                     if (ret != RCL_RET_OK) {
                         ESP_LOGE(TAG, "Failed to finalize rcl init options: %ld", ret);
                     }
+                } else {
+                    ESP_LOGW(TAG, "micro-ROS agent not found via mDNS host '%s.local'", CONFIG_MICROROS_AGENT_MDNS_HOST);
                 }
                 vTaskDelay(pdMS_TO_TICKS(2000));
                 break;

--- a/components/wifi_manager/wifi_manager.cpp
+++ b/components/wifi_manager/wifi_manager.cpp
@@ -17,6 +17,14 @@ static constexpr cred_t s_creds[] = {
 static constexpr int CRED_COUNT = static_cast<int>(std::size(s_creds));
 static_assert(CRED_COUNT > 0, "no credential slots defined");  // guardrail
 
+static int valid_cred_count() {
+    int valid = 0;
+    for (int i = 0; i < CRED_COUNT; i++) {
+        if (s_creds[i].ssid && s_creds[i].ssid[0] != '\0') valid++;
+    }
+    return valid;
+}
+
 // -------------------------------------------------------------------
 // Tuning from Kconfig
 // -------------------------------------------------------------------
@@ -266,10 +274,18 @@ static bool monitor_rssi() {
 // Manager task
 // -------------------------------------------------------------------
 [[noreturn]] static void manager_task(void *arg) {
-    ESP_LOGI(TAG, "manager task started, %d credential slot(s)", CRED_COUNT);
+    ESP_LOGI(TAG, "manager task started, %d credential slot(s), %d configured",
+             CRED_COUNT, valid_cred_count());
     for (int i = 0; i < CRED_COUNT; i++) {
         if (s_creds[i].ssid && s_creds[i].ssid[0] != '\0')
             ESP_LOGI(TAG, "  [%d] \"%s\"", i, s_creds[i].ssid);
+        else
+            ESP_LOGI(TAG, "  [%d] <empty>", i);
+    }
+
+    if (valid_cred_count() == 0) {
+        ESP_LOGE(TAG, "no Wi-Fi SSIDs configured; set CONFIG_WIFI_SSID_1..4 in menuconfig");
+        vTaskDelete(nullptr);
     }
     int  ci        = -1;
     bool skip_scan = false;

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -77,3 +77,12 @@ menu "Wi-Fi Configuration"
             When no known AP is visible, wait this many seconds before rescanning.
 
 endmenu
+
+menu "micro-ROS Configuration"
+    config MICROROS_AGENT_MDNS_HOST
+        string "micro-ROS agent mDNS hostname"
+        default "gentoo-laptop"
+        help
+            mDNS hostname (without .local) used by firmware to discover the micro-ROS agent.
+            Example: set to "burger-desktop" for burger-desktop.local.
+endmenu


### PR DESCRIPTION
### Motivation

- Make micro-ROS agent discovery configurable instead of hard-coding a hostname to support different development hosts and deployments.
- Improve runtime observability of micro-ROS lifecycle, publishers, and subscriptions to simplify debugging of agent connectivity and message flow.
- Fail early and provide clear diagnostics when no Wi‑Fi credentials are configured to avoid silent startup failures.

### Description

- Use `CONFIG_MICROROS_AGENT_MDNS_HOST` in `components/shelfbot/shelfbot.cpp` for mDNS agent lookup and emit a warning when the agent is not found via mDNS.
- Add informative `ESP_LOGI`/`ESP_LOGD` messages around micro-ROS lifecycle events, node/publisher/subscription creation, executor configuration, and each publisher/subscriber callback for better runtime tracing.
- Add `valid_cred_count()` and enhance `components/wifi_manager/wifi_manager.cpp` to log configured SSID slots, show `<empty>` entries, and abort the manager task with an error when no SSIDs are configured.
- Update `main/Kconfig.projbuild` to add a `MICROROS_AGENT_MDNS_HOST` Kconfig entry and update `README.md` with micro-ROS lifecycle troubleshooting commands and updated troubleshooting guidance.

### Testing

- Built the firmware with the project configuration using `idf.py build` and the build completed successfully.
- Verified Kconfig integration by running `menuconfig` and confirming the new `MICROROS_AGENT_MDNS_HOST` option and Wi‑Fi config values are exposed and usable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a106baa274c8322b4827508fd831484)